### PR TITLE
logger: add question mark for query strings

### DIFF
--- a/lib/src/handlers/logger.dart
+++ b/lib/src/handlers/logger.dart
@@ -50,10 +50,14 @@ Middleware logRequests({void logger(String msg, bool isError)}) =>
   };
 };
 
+String _hasQuery(String query) {
+  return query == '' ? '' : '?';
+}
+
 String _getMessage(DateTime requestTime, int statusCode, Uri requestedUri,
     String method, Duration elapsedTime) {
   return '${requestTime}\t$elapsedTime\t$method\t[${statusCode}]\t'
-      '${requestedUri.path}${requestedUri.query}';
+      '${requestedUri.path}${_hasQuery(requestedUri.query)}${requestedUri.query}';
 }
 
 String _getErrorMessage(DateTime requestTime, Uri requestedUri, String method,
@@ -65,7 +69,7 @@ String _getErrorMessage(DateTime requestTime, Uri requestedUri, String method,
   }
 
   var msg = '${requestTime}\t$elapsedTime\t$method\t${requestedUri.path}'
-      '${requestedUri.query}\n$error';
+      '${_hasQuery(requestedUri.query)}${requestedUri.query}\n$error';
   if (chain == null) return msg;
 
   return '$msg\n$chain';

--- a/lib/src/handlers/logger.dart
+++ b/lib/src/handlers/logger.dart
@@ -50,14 +50,14 @@ Middleware logRequests({void logger(String msg, bool isError)}) =>
   };
 };
 
-String _hasQuery(String query) {
-  return query == '' ? '' : '?';
+String _formatQuery(String query) {
+  return query == '' ? '' : '?$query';
 }
 
 String _getMessage(DateTime requestTime, int statusCode, Uri requestedUri,
     String method, Duration elapsedTime) {
   return '${requestTime}\t$elapsedTime\t$method\t[${statusCode}]\t'
-      '${requestedUri.path}${_hasQuery(requestedUri.query)}${requestedUri.query}';
+      '${requestedUri.path}${_formatQuery(requestedUri.query)}';
 }
 
 String _getErrorMessage(DateTime requestTime, Uri requestedUri, String method,
@@ -69,7 +69,7 @@ String _getErrorMessage(DateTime requestTime, Uri requestedUri, String method,
   }
 
   var msg = '${requestTime}\t$elapsedTime\t$method\t${requestedUri.path}'
-      '${_hasQuery(requestedUri.query)}${requestedUri.query}\n$error';
+      '${_formatQuery(requestedUri.query)}\n$error';
   if (chain == null) return msg;
 
   return '$msg\n$chain';


### PR DESCRIPTION
Looks better now 

```
Serving at http://localhost:8080
2015-05-11 13:20:42.860	0:00:00.004868	GET	[200]	/abcd?d=e&f=g
2015-05-11 13:20:43.102	0:00:00.000332	GET	[200]	/favicon.ico
2015-05-11 13:20:58.503	0:00:00.000988	GET	[200]	/?d=e&f=g
2015-05-11 13:20:58.732	0:00:00.002255	GET	[200]	/favicon.ico
```