### PR TITLE
Headers values allow List<String> in addition to List.

### DIFF
--- a/lib/src/message.dart
+++ b/lib/src/message.dart
@@ -18,7 +18,7 @@ abstract class Message {
   /// The HTTP headers.
   ///
   /// The value is immutable.
-  final Map<String, String> headers;
+  final Map<String, Object> headers;
 
   /// Extra context that can be used by for middleware and handlers.
   ///
@@ -56,10 +56,10 @@ abstract class Message {
   /// If [encoding] is passed, the "encoding" field of the Content-Type header
   /// in [headers] will be set appropriately. If there is no existing
   /// Content-Type header, it will be set to "application/octet-stream".
-  Message(body, {Encoding encoding, Map<String, String> headers,
+  Message(body, {Encoding encoding, Map<String, Object> headers,
       Map<String, Object> context})
       : this._body = _bodyToStream(body, encoding),
-        this.headers = new ShelfUnmodifiableMap<String>(
+        this.headers = new ShelfUnmodifiableMap<Object>(
             _adjustHeaders(headers, encoding), ignoreKeyCase: true),
         this.context = new ShelfUnmodifiableMap<Object>(context,
             ignoreKeyCase: false);
@@ -139,7 +139,7 @@ abstract class Message {
 
   /// Creates a new [Message] by copying existing values and applying specified
   /// changes.
-  Message change({Map<String, String> headers, Map<String, Object> context});
+  Message change({Map<String, Object> headers, Map<String, Object> context});
 }
 
 /// Converts [body] to a byte stream.
@@ -159,8 +159,8 @@ Stream<List<int>> _bodyToStream(body, Encoding encoding) {
 /// Adds information about [encoding] to [headers].
 ///
 /// Returns a new map without modifying [headers].
-Map<String, String> _adjustHeaders(
-    Map<String, String> headers, Encoding encoding) {
+Map<String, Object> _adjustHeaders(
+    Map<String, Object> headers, Encoding encoding) {
   if (headers == null) headers = const {};
   if (encoding == null) return headers;
   if (headers['content-type'] == null) {

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -133,7 +133,7 @@ class Request extends Message {
   /// See also [hijack].
   // TODO(kevmoo) finish documenting the rest of the arguments.
   Request(String method, Uri requestedUri, {String protocolVersion,
-      Map<String, String> headers, String handlerPath, Uri url, body,
+      Map<String, Object> headers, String handlerPath, Uri url, body,
       Encoding encoding, Map<String, Object> context,
       OnHijackCallback onHijack})
       : this._(method, requestedUri,
@@ -153,7 +153,7 @@ class Request extends Message {
   /// source [Request] to ensure that [hijack] can only be called once, even
   /// from a changed [Request].
   Request._(this.method, Uri requestedUri, {String protocolVersion,
-      Map<String, String> headers, String handlerPath, Uri url, body,
+      Map<String, Object> headers, String handlerPath, Uri url, body,
       Encoding encoding, Map<String, Object> context, _OnHijack onHijack})
       : this.requestedUri = requestedUri,
         this.protocolVersion = protocolVersion == null
@@ -202,7 +202,7 @@ class Request extends Message {
   ///     request = request.change(path: "dir");
   ///     print(request.handlerPath); // => /static/dir/
   ///     print(request.url);        // => file.html
-  Request change({Map<String, String> headers, Map<String, Object> context,
+  Request change({Map<String, Object> headers, Map<String, Object> context,
       String path}) {
     headers = updateMap(this.headers, headers);
     context = updateMap(this.context, context);

--- a/lib/src/response.dart
+++ b/lib/src/response.dart
@@ -53,7 +53,7 @@ class Response extends Message {
   /// If [encoding] is passed, the "encoding" field of the Content-Type header
   /// in [headers] will be set appropriately. If there is no existing
   /// Content-Type header, it will be set to "application/octet-stream".
-  Response.ok(body, {Map<String, String> headers, Encoding encoding,
+  Response.ok(body, {Map<String, Object> headers, Encoding encoding,
     Map<String, Object> context})
       : this(200, body: body, headers: headers, encoding: encoding,
           context: context);
@@ -72,7 +72,7 @@ class Response extends Message {
   /// If [encoding] is passed, the "encoding" field of the Content-Type header
   /// in [headers] will be set appropriately. If there is no existing
   /// Content-Type header, it will be set to "application/octet-stream".
-  Response.movedPermanently(location, {body, Map<String, String> headers,
+  Response.movedPermanently(location, {body, Map<String, Object> headers,
       Encoding encoding, Map<String, Object> context})
       : this._redirect(301, location, body, headers, encoding,
           context: context);
@@ -91,7 +91,7 @@ class Response extends Message {
   /// If [encoding] is passed, the "encoding" field of the Content-Type header
   /// in [headers] will be set appropriately. If there is no existing
   /// Content-Type header, it will be set to "application/octet-stream".
-  Response.found(location, {body, Map<String, String> headers,
+  Response.found(location, {body, Map<String, Object> headers,
       Encoding encoding, Map<String, Object> context})
       : this._redirect(302, location, body, headers, encoding,
           context: context);
@@ -111,14 +111,14 @@ class Response extends Message {
   /// If [encoding] is passed, the "encoding" field of the Content-Type header
   /// in [headers] will be set appropriately. If there is no existing
   /// Content-Type header, it will be set to "application/octet-stream".
-  Response.seeOther(location, {body, Map<String, String> headers,
+  Response.seeOther(location, {body, Map<String, Object> headers,
       Encoding encoding, Map<String, Object> context})
       : this._redirect(303, location, body, headers, encoding,
           context: context);
 
   /// Constructs a helper constructor for redirect responses.
   Response._redirect(int statusCode, location, body,
-      Map<String, String> headers, Encoding encoding,
+      Map<String, Object> headers, Encoding encoding,
       { Map<String, Object> context })
       : this(statusCode,
             body: body,
@@ -133,7 +133,7 @@ class Response extends Message {
   /// information used to determine whether the requested resource has changed
   /// since the last request. It indicates that the resource has not changed and
   /// the old value should be used.
-  Response.notModified({Map<String, String> headers,
+  Response.notModified({Map<String, Object> headers,
     Map<String, Object> context})
       : this(304, headers: addHeader(
             headers, 'date', formatHttpDate(new DateTime.now())),
@@ -151,7 +151,7 @@ class Response extends Message {
   /// If [encoding] is passed, the "encoding" field of the Content-Type header
   /// in [headers] will be set appropriately. If there is no existing
   /// Content-Type header, it will be set to "application/octet-stream".
-  Response.forbidden(body, {Map<String, String> headers,
+  Response.forbidden(body, {Map<String, Object> headers,
       Encoding encoding, Map<String, Object> context})
       : this(403,
           headers: body == null ? _adjustErrorHeaders(headers) : headers,
@@ -171,7 +171,7 @@ class Response extends Message {
   /// If [encoding] is passed, the "encoding" field of the Content-Type header
   /// in [headers] will be set appropriately. If there is no existing
   /// Content-Type header, it will be set to "application/octet-stream".
-  Response.notFound(body, {Map<String, String> headers, Encoding encoding,
+  Response.notFound(body, {Map<String, Object> headers, Encoding encoding,
     Map<String, Object> context})
       : this(404,
           headers: body == null ? _adjustErrorHeaders(headers) : headers,
@@ -191,7 +191,7 @@ class Response extends Message {
   /// If [encoding] is passed, the "encoding" field of the Content-Type header
   /// in [headers] will be set appropriately. If there is no existing
   /// Content-Type header, it will be set to "application/octet-stream".
-  Response.internalServerError({body, Map<String, String> headers,
+  Response.internalServerError({body, Map<String, Object> headers,
       Encoding encoding, Map<String, Object> context})
       : this(500,
             headers: body == null ? _adjustErrorHeaders(headers) : headers,
@@ -210,7 +210,7 @@ class Response extends Message {
   /// If [encoding] is passed, the "encoding" field of the Content-Type header
   /// in [headers] will be set appropriately. If there is no existing
   /// Content-Type header, it will be set to "application/octet-stream".
-  Response(this.statusCode, {body, Map<String, String> headers,
+  Response(this.statusCode, {body, Map<String, Object> headers,
       Encoding encoding, Map<String, Object> context})
       : super(body, encoding: encoding, headers: headers, context: context) {
     if (statusCode < 100) {
@@ -230,7 +230,7 @@ class Response extends Message {
   ///
   /// All other context and header values from the [Response] will be included
   /// in the copied [Response] unchanged.
-  Response change({Map<String, String> headers, Map<String, Object> context}) {
+  Response change({Map<String, Object> headers, Map<String, Object> context}) {
     headers = updateMap(this.headers, headers);
     context = updateMap(this.context, context);
 
@@ -243,7 +243,7 @@ class Response extends Message {
 ///
 /// Returns a new map without modifying [headers]. This is used to add
 /// content-type information when creating a 500 response with a default body.
-Map<String, String> _adjustErrorHeaders(Map<String, String> headers) {
+Map<String, String> _adjustErrorHeaders(Map<String, Object> headers) {
   if (headers == null || headers['content-type'] == null) {
     return addHeader(headers, 'content-type', 'text/plain');
   }


### PR DESCRIPTION
* This works because shelf uses dart:io HttpServer internally, which
  already accepts lists in its Http server.
* This to address the Set-Cookie edge-case.
* Closes dart-lang/shelf#44