### PR TITLE
Accept List<int> message bodies.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ dart:
   - 1.15.0
   - 1.14.2
   - 1.13.2
-  - 1.12.2
 cache:
   directories:
     - $HOME/.pub-cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 0.6.6
+
+* Allow `List<int>`s to be passed as request or response bodies.
+
+* Requests and responses now automatically set `Content-Length` headers when the
+  body length is known ahead of time.
+
+* Work around [sdk#27660][] by manually setting
+  `HttpResponse.chunkedTransferEncoding` to `false` for requests known to have
+  no content.
+
+[sdk#27660]: https://github.com/dart-lang/sdk/issues/27660
+
 ## 0.6.5+3
 
 * Improve the documentation of `logRequests()`.

--- a/lib/shelf_io.dart
+++ b/lib/shelf_io.dart
@@ -149,6 +149,11 @@ Future _writeResponse(Response response, HttpResponse httpResponse) {
     httpResponse.headers.date = new DateTime.now().toUtc();
   }
 
+  // Work around sdk#27660.
+  if (response.contentLength == 0) {
+    httpResponse.headers.chunkedTransferEncoding = false;
+  }
+
   return httpResponse
       .addStream(response.read())
       .then((_) => httpResponse.close());

--- a/lib/src/body.dart
+++ b/lib/src/body.dart
@@ -78,7 +78,7 @@ class Body {
 
     // Non-ASCII code units between U+0080 and U+009F produce 8-bit characters
     // with the high bit set.
-    return bytes.any((byte) => byte & 0x80 != 0);
+    return bytes.every((byte) => byte & 0x80 == 0);
   }
 
   /// Returns a [Stream] representing the body.

--- a/lib/src/body.dart
+++ b/lib/src/body.dart
@@ -5,8 +5,8 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:collection/collection.dart';
 import 'package:async/async.dart';
+import 'package:collection/collection.dart';
 
 /// The body of a request or response.
 ///
@@ -76,13 +76,9 @@ class Body {
     // longer.
     if (bytes.length != codeUnits) return false;
 
-    for (var byte in bytes) {
-      // Non-ASCII code units between U+0080 and U+009F produce 8-bit
-      // characters with the high bit set.
-      if (byte & 0x80 != 0) return false;
-    }
-
-    return true;
+    // Non-ASCII code units between U+0080 and U+009F produce 8-bit characters
+    // with the high bit set.
+    return bytes.any((byte) => byte & 0x80 != 0);
   }
 
   /// Returns a [Stream] representing the body.

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -96,10 +96,10 @@ class Request extends Message {
   /// and [url] to `requestedUri.path` without the initial `/`. If only one is
   /// passed, the other will be inferred.
   ///
-  /// [body] is the request body. It may be either a [String], a
-  /// [Stream<List<int>>], or `null` to indicate no body.
-  /// If it's a [String], [encoding] is used to encode it to a
-  /// [Stream<List<int>>]. The default encoding is UTF-8.
+  /// [body] is the request body. It may be either a [String], a [List<int>], a
+  /// [Stream<List<int>>], or `null` to indicate no body. If it's a [String],
+  /// [encoding] is used to encode it to a [Stream<List<int>>]. The default
+  /// encoding is UTF-8.
   ///
   /// If [encoding] is passed, the "encoding" field of the Content-Type header
   /// in [headers] will be set appropriately. If there is no existing
@@ -192,8 +192,8 @@ class Request extends Message {
   /// [Request]. All other context and header values from the [Request] will be
   /// included in the copied [Request] unchanged.
   ///
-  /// [body] is the request body. It may be either a [String] or a
-  /// [Stream<List<int>>].
+  /// [body] is the request body. It may be either a [String], a [List<int>], a
+  /// [Stream<List<int>>], or `null` to indicate no body.
   ///
   /// [path] is used to update both [handlerPath] and [url]. It's designed for
   /// routing middleware, and represents the path from the current handler to

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -105,6 +105,9 @@ class Request extends Message {
   /// in [headers] will be set appropriately. If there is no existing
   /// Content-Type header, it will be set to "application/octet-stream".
   ///
+  /// If a non-[Stream] object is passed for the [body], the Content-Length
+  /// header is automatically set to the length of that body.
+  ///
   /// The default value for [protocolVersion] is '1.1'.
   ///
   /// ## `onHijack`

--- a/lib/src/response.dart
+++ b/lib/src/response.dart
@@ -43,7 +43,7 @@ class Response extends Message {
   ///
   /// This indicates that the request has succeeded.
   ///
-  /// [body] is the response body. It may be either a [String], a
+  /// [body] is the response body. It may be either a [String], a [List<int>], a
   /// [Stream<List<int>>], or `null` to indicate no body. If it's a [String],
   /// [encoding] is used to encode it to a [Stream<List<int>>]. It defaults to
   /// UTF-8.
@@ -62,7 +62,7 @@ class Response extends Message {
   /// URI. [location] is that URI; it can be either a [String] or a [Uri]. It's
   /// automatically set as the Location header in [headers].
   ///
-  /// [body] is the response body. It may be either a [String], a
+  /// [body] is the response body. It may be either a [String], a [List<int>], a
   /// [Stream<List<int>>], or `null` to indicate no body. If it's a [String],
   /// [encoding] is used to encode it to a [Stream<List<int>>]. It defaults to
   /// UTF-8.
@@ -81,7 +81,7 @@ class Response extends Message {
   /// URI. [location] is that URI; it can be either a [String] or a [Uri]. It's
   /// automatically set as the Location header in [headers].
   ///
-  /// [body] is the response body. It may be either a [String], a
+  /// [body] is the response body. It may be either a [String], a [List<int>], a
   /// [Stream<List<int>>], or `null` to indicate no body. If it's a [String],
   /// [encoding] is used to encode it to a [Stream<List<int>>]. It defaults to
   /// UTF-8.
@@ -101,7 +101,7 @@ class Response extends Message {
   /// [String] or a [Uri]. It's automatically set as the Location header in
   /// [headers].
   ///
-  /// [body] is the response body. It may be either a [String], a
+  /// [body] is the response body. It may be either a [String], a [List<int>], a
   /// [Stream<List<int>>], or `null` to indicate no body. If it's a [String],
   /// [encoding] is used to encode it to a [Stream<List<int>>]. It defaults to
   /// UTF-8.
@@ -141,10 +141,10 @@ class Response extends Message {
   ///
   /// This indicates that the server is refusing to fulfill the request.
   ///
-  /// [body] is the response body. It may be a [String], a [Stream<List<int>>],
-  /// or `null`. If it's a [String], [encoding] is used to encode it to a
-  /// [Stream<List<int>>]. The default encoding is UTF-8. If it's `null` or not
-  /// passed, a default error message is used.
+  /// [body] is the response body. It may be a [String], a [List<int>], a
+  /// [Stream<List<int>>], or `null`. If it's a [String], [encoding] is used to
+  /// encode it to a [Stream<List<int>>]. The default encoding is UTF-8. If it's
+  /// `null` or not passed, a default error message is used.
   ///
   /// If [encoding] is passed, the "encoding" field of the Content-Type header
   /// in [headers] will be set appropriately. If there is no existing
@@ -161,10 +161,10 @@ class Response extends Message {
   /// This indicates that the server didn't find any resource matching the
   /// requested URI.
   ///
-  /// [body] is the response body. It may be a [String], a [Stream<List<int>>],
-  /// or `null`. If it's a [String], [encoding] is used to encode it to a
-  /// [Stream<List<int>>]. The default encoding is UTF-8. If it's `null` or not
-  /// passed, a default error message is used.
+  /// [body] is the response body. It may be a [String], a [List<int>], a
+  /// [Stream<List<int>>], or `null`. If it's a [String], [encoding] is used to
+  /// encode it to a [Stream<List<int>>]. The default encoding is UTF-8. If it's
+  /// `null` or not passed, a default error message is used.
   ///
   /// If [encoding] is passed, the "encoding" field of the Content-Type header
   /// in [headers] will be set appropriately. If there is no existing
@@ -181,10 +181,10 @@ class Response extends Message {
   /// This indicates that the server had an internal error that prevented it
   /// from fulfilling the request.
   ///
-  /// [body] is the response body. It may be a [String], a [Stream<List<int>>],
-  /// or `null`. If it's a [String], [encoding] is used to encode it to a
-  /// [Stream<List<int>>]. The default encoding is UTF-8. If it's `null` or not
-  /// passed, a default error message is used.
+  /// [body] is the response body. It may be a [String], a [List<int>], a
+  /// [Stream<List<int>>], or `null`. If it's a [String], [encoding] is used to
+  /// encode it to a [Stream<List<int>>]. The default encoding is UTF-8. If it's
+  /// `null` or not passed, a default error message is used.
   ///
   /// If [encoding] is passed, the "encoding" field of the Content-Type header
   /// in [headers] will be set appropriately. If there is no existing
@@ -200,10 +200,10 @@ class Response extends Message {
   ///
   /// [statusCode] must be greater than or equal to 100.
   ///
-  /// [body] is the response body. It may be either a [String], a
-  /// [Stream<List<int>>], or `null` to indicate no body.
-  /// If it's a [String], [encoding] is used to encode it to a
-  /// [Stream<List<int>>]. The default encoding is UTF-8.
+  /// [body] is the response body. It may be either a [String], a [List<int>], a
+  /// [Stream<List<int>>], or `null` to indicate no body. If it's a [String],
+  /// [encoding] is used to encode it to a [Stream<List<int>>]. The default
+  /// encoding is UTF-8.
   ///
   /// If [encoding] is passed, the "encoding" field of the Content-Type header
   /// in [headers] will be set appropriately. If there is no existing
@@ -229,8 +229,8 @@ class Response extends Message {
   /// All other context and header values from the [Response] will be included
   /// in the copied [Response] unchanged.
   ///
-  /// [body] is the request body. It may be either a [String] or a
-  /// [Stream<List<int>>].
+  /// [body] is the request body. It may be either a [String], a [List<int>], a
+  /// [Stream<List<int>>], or `null` to indicate no body.
   Response change(
       {Map<String, String> headers, Map<String, Object> context, body}) {
     headers = updateMap(this.headers, headers);

--- a/lib/src/response.dart
+++ b/lib/src/response.dart
@@ -208,6 +208,9 @@ class Response extends Message {
   /// If [encoding] is passed, the "encoding" field of the Content-Type header
   /// in [headers] will be set appropriately. If there is no existing
   /// Content-Type header, it will be set to "application/octet-stream".
+  ///
+  /// If a non-[Stream] object is passed for the [body], the Content-Length
+  /// header is automatically set to the length of that body.
   Response(this.statusCode, {body, Map<String, String> headers,
       Encoding encoding, Map<String, Object> context})
       : super(body, encoding: encoding, headers: headers, context: context) {

--- a/lib/src/shelf_unmodifiable_map.dart
+++ b/lib/src/shelf_unmodifiable_map.dart
@@ -4,6 +4,7 @@
 
 import 'dart:collection';
 
+import 'package:collection/collection.dart';
 import 'package:http_parser/http_parser.dart';
 
 /// A simple wrapper over [UnmodifiableMapView] which avoids re-wrapping itself.
@@ -41,6 +42,9 @@ class ShelfUnmodifiableMap<V> extends UnmodifiableMapView<String, V> {
 
     return new ShelfUnmodifiableMap<V>._(source, ignoreKeyCase);
   }
+
+  /// Returns an empty [ShelfUnmodifiableMap].
+  const factory ShelfUnmodifiableMap.empty() = _EmptyShelfUnmodifiableMap<V>;
 
   ShelfUnmodifiableMap._(Map<String, V> source, this._ignoreKeyCase)
       : super(source);

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -4,6 +4,10 @@
 
 import 'dart:async';
 
+import 'package:collection/collection.dart';
+
+import 'shelf_unmodifiable_map.dart';
+
 /// Like [new Future], but avoids around issue 11911 by using [new Future.value]
 /// under the covers.
 Future newFuture(callback()) => new Future.value().then((_) => callback());
@@ -43,4 +47,18 @@ Map<String, String> addHeader(
   headers = headers == null ? {} : new Map.from(headers);
   headers[name] = value;
   return headers;
+}
+
+/// Returns the header with the given [name] in [headers].
+///
+/// This works even if [headers] is `null`, or if it's not yet a
+/// case-insensitive map.
+String getHeader(Map<String, String> headers, String name) {
+  if (headers == null) return null;
+  if (headers is ShelfUnmodifiableMap) return headers[name];
+
+  for (var key in headers.keys) {
+    if (equalsIgnoreAsciiCase(key, name)) return headers[key];
+  }
+  return null;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf
-version: 0.6.5+3
+version: 0.6.6
 author: Dart Team <misc@dartlang.org>
 description: Web Server Middleware for Dart
 homepage: https://github.com/dart-lang/shelf
@@ -7,6 +7,7 @@ environment:
   sdk: '>=1.12.0 <2.0.0'
 dependencies:
   async: '^1.10.0'
+  collection: '^1.5.0'
   http_parser: '>=1.0.0 <4.0.0'
   path: '^1.0.0'
   stack_trace: '^1.0.0'

--- a/test/message_change_test.dart
+++ b/test/message_change_test.dart
@@ -53,7 +53,7 @@ void _testChange(Message factory(
     });
   });
 
-  test('with empty headers returns indentical instance', () {
+  test('with empty headers returns identical instance', () {
     var request = factory(headers: {'header1': 'header value 1'});
     var copy = request.change(headers: {});
 
@@ -71,14 +71,18 @@ void _testChange(Message factory(
     var request = factory(headers: {'test': 'test value'});
     var copy = request.change(headers: {'test2': 'test2 value'});
 
-    expect(copy.headers, {'test': 'test value', 'test2': 'test2 value'});
+    expect(copy.headers, {
+      'test': 'test value',
+      'test2': 'test2 value',
+      'content-length': '0'
+    });
   });
 
   test('existing header values are overwritten', () {
     var request = factory(headers: {'test': 'test value'});
     var copy = request.change(headers: {'test': 'new test value'});
 
-    expect(copy.headers, {'test': 'new test value'});
+    expect(copy.headers, {'test': 'new test value', 'content-length': '0'});
   });
 
   test('new context values are added', () {


### PR DESCRIPTION
This also automatically sets the content-length header when possible,
and works around dart-lang/sdk#27660.