### PR TITLE
Add Message.isEmpty.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.6.7
+
+* Add `Request.isEmpty` and `Response.isEmpty` getters which indicate whether a
+  message has an empty body.
+
+* Don't automatically generate `Content-Length` headers on messages where they
+  may not be allowed.
+
+* User-specified `Content-Length` headers now always take precedence over
+  automatically-generated headers.
+
 ## 0.6.6
 
 * Allow `List<int>`s to be passed as request or response bodies.

--- a/lib/shelf_io.dart
+++ b/lib/shelf_io.dart
@@ -150,9 +150,7 @@ Future _writeResponse(Response response, HttpResponse httpResponse) {
   }
 
   // Work around sdk#27660.
-  if (response.contentLength == 0) {
-    httpResponse.headers.chunkedTransferEncoding = false;
-  }
+  if (response.isEmpty) httpResponse.headers.chunkedTransferEncoding = false;
 
   return httpResponse
       .addStream(response.read())

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -62,3 +62,17 @@ String getHeader(Map<String, String> headers, String name) {
   }
   return null;
 }
+
+/// Returns whether [headers] contains a header with the given [name].
+///
+/// This works even if [headers] is `null`, or if it's not yet a
+/// case-insensitive map.
+bool hasHeader(Map<String, String> headers, String name) {
+  if (headers == null) return false;
+  if (headers is ShelfUnmodifiableMap) return headers.containsKey(name);
+
+  for (var key in headers.keys) {
+    if (equalsIgnoreAsciiCase(key, name)) return true;
+  }
+  return false;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf
-version: 0.6.6
+version: 0.6.7
 author: Dart Team <misc@dartlang.org>
 description: Web Server Middleware for Dart
 homepage: https://github.com/dart-lang/shelf

--- a/test/message_test.dart
+++ b/test/message_test.dart
@@ -164,26 +164,28 @@ void main() {
       expect(request.contentLength, 0);
     });
 
-    test("comes from a byte body", () {
-      var request = _createMessage(body: [1, 2, 3]);
-      expect(request.contentLength, 3);
+    test("is 0 with an empty byte body", () {
+      var request = _createMessage(body: []);
+      expect(request.contentLength, 0);
     });
 
-    test("comes from a string body", () {
-      var request = _createMessage(body: 'foobar');
-      expect(request.contentLength, 6);
+    test("is 0 with an empty string body", () {
+      var request = _createMessage(body: '');
+      expect(request.contentLength, 0);
     });
 
-    test("is set based on byte length for a string body", () {
-      var request = _createMessage(body: 'fööbär');
-      expect(request.contentLength, 9);
-
-      request = _createMessage(body: 'fööbär', encoding: LATIN1);
-      expect(request.contentLength, 6);
-    });
-
-    test("is null for a stream body", () {
+    test("is null for an empty stream body", () {
       var request = _createMessage(body: new Stream.empty());
+      expect(request.contentLength, isNull);
+    });
+
+    test("is null for a non-empty byte body", () {
+      var request = _createMessage(body: [1, 2, 3]);
+      expect(request.contentLength, isNull);
+    });
+
+    test("is null for a non-empty string body", () {
+      var request = _createMessage(body: "foo");
       expect(request.contentLength, isNull);
     });
 
@@ -193,10 +195,9 @@ void main() {
       expect(request.contentLength, 42);
     });
 
-    test("real body length takes precedence over content-length header", () {
-      var request = _createMessage(
-          body: [1, 2, 3], headers: {'content-length': '42'});
-      expect(request.contentLength, 3);
+    test("content-length header takes precedence over an empty body", () {
+      var request = _createMessage(headers: {'content-length': '42'});
+      expect(request.contentLength, 42);
     });
   });
 


### PR DESCRIPTION
This also fixes some logic bugs with the previous release. In
particular, it doesn't send Content-Length headers along with chunked
transfer encodings, and it allows users to override the automatic
Content-Length.