### PR TITLE
Allow package:async v2.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/dart-lang/shelf
 environment:
   sdk: '>=1.22.0 <2.0.0-dev.infinity'
 dependencies:
-  async: '^1.10.0'
+  async: '>=1.10.0 <3.0.0'
   collection: '^1.5.0'
   http_parser: '^3.1.0'
   path: '^1.0.0'


### PR DESCRIPTION
Tested with a dependency override, dartanalyzer and pub run test are
clean.