### PR TITLE
Update `createMiddleware` arguments to use `FutureOr`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 dart:
   - dev
   - stable
-  - 1.23.0
 
 dart_task:
   - test: --platform vm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.8.0
+
+* Update `createMiddleware` arguments to use `FutureOr`.
+
+  * Note: this change is not breaking for the runtime behavior, but it might
+    cause new errors during static analysis due the the type changes. When
+    updating packages that depend on `shelf`, it is safe to include `0.7.1` in
+    your version range.
+
+      `shelf: '>=0.7.1 <0.9.0'`
+
 ## 0.7.1
 
 * The `shelf_io` server now adds a `shelf.io.connection_info` field to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,11 @@
-## 0.8.0
+## 0.7.2
 
 * Update `createMiddleware` arguments to use `FutureOr`.
 
   * Note: this change is not breaking for the runtime behavior, but it might
-    cause new errors during static analysis due the the type changes. When
-    updating packages that depend on `shelf`, it is safe to include `0.7.1` in
-    your version range.
+    cause new errors during static analysis due the the type changes.
 
-      `shelf: '>=0.7.1 <0.9.0'`
+* Updated minimum Dart SDK to `1.24.0`, which added `FutureOr`.
 
 ## 0.7.1
 

--- a/lib/src/middleware.dart
+++ b/lib/src/middleware.dart
@@ -47,9 +47,9 @@ typedef Handler Middleware(Handler innerHandler);
 /// does it receive [HijackException]s. It can either return a new response or
 /// throw an error.
 Middleware createMiddleware(
-    {requestHandler(Request request),
-    responseHandler(Response response),
-    errorHandler(error, StackTrace stackTrace)}) {
+    {FutureOr<Response> requestHandler(Request request),
+    FutureOr<Response> responseHandler(Response response),
+    FutureOr<Response> errorHandler(error, StackTrace stackTrace)}) {
   if (requestHandler == null) requestHandler = (request) => null;
 
   if (responseHandler == null) responseHandler = (response) => response;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf
-version: 0.8.0-dev
+version: 0.7.2-dev
 author: Dart Team <misc@dartlang.org>
 description: Web Server Middleware for Dart
 homepage: https://github.com/dart-lang/shelf

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: shelf
-version: 0.7.1
+version: 0.8.0-dev
 author: Dart Team <misc@dartlang.org>
 description: Web Server Middleware for Dart
 homepage: https://github.com/dart-lang/shelf
 environment:
-  sdk: '>=1.23.0 <2.0.0'
+  sdk: '>=1.24.0 <2.0.0'
 dependencies:
   async: '>=1.10.0 <3.0.0'
   collection: '^1.5.0'

--- a/test/create_middleware_test.dart
+++ b/test/create_middleware_test.dart
@@ -9,6 +9,11 @@ import 'package:test/test.dart';
 
 import 'test_util.dart';
 
+// TODO(kevmoo): remove this helper https://github.com/dart-lang/test/issues/740
+T _fail<T>(String message) {
+  fail(message);
+}
+
 void main() {
   test('forwards the request and response if both handlers are null', () {
     var handler = const Pipeline()
@@ -71,7 +76,7 @@ void main() {
       test('with sync result, responseHandler is not called', () {
         var middleware = createMiddleware(
             requestHandler: (request) => _middlewareResponse,
-            responseHandler: (response) => fail('should not be called'));
+            responseHandler: (response) => _fail('should not be called'));
 
         var handler =
             const Pipeline().addMiddleware(middleware).addHandler(syncHandler);
@@ -84,7 +89,7 @@ void main() {
       test('with async result, responseHandler is not called', () {
         var middleware = createMiddleware(
             requestHandler: (request) => new Future.value(_middlewareResponse),
-            responseHandler: (response) => fail('should not be called'));
+            responseHandler: (response) => _fail('should not be called'));
         var handler =
             const Pipeline().addMiddleware(middleware).addHandler(syncHandler);
 
@@ -151,7 +156,7 @@ void main() {
           responseHandler: (response) {
             throw 'middleware error';
           },
-          errorHandler: (e, s) => fail('should never get here'));
+          errorHandler: (e, s) => _fail('should never get here'));
 
       var handler =
           const Pipeline().addMiddleware(middleware).addHandler(syncHandler);
@@ -164,7 +169,7 @@ void main() {
           requestHandler: (request) {
             throw 'middleware error';
           },
-          errorHandler: (e, s) => fail('should never get here'));
+          errorHandler: (e, s) => _fail('should never get here'));
 
       var handler =
           const Pipeline().addMiddleware(middleware).addHandler(syncHandler);
@@ -230,10 +235,7 @@ void main() {
   });
 }
 
-Response _failHandler(Request request) {
-  fail('should never get here');
-  return null;
-}
+Response _failHandler(Request request) => _fail('should never get here');
 
 final Response _middlewareResponse =
     new Response.ok('middleware content', headers: {'from': 'middleware'});


### PR DESCRIPTION
Note: this change is not breaking for the runtime behavior, but it might
cause new errors during static analysis due the the type changes.