### PR TITLE
Use types in const expression to prevent evaluation exception in anal…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.3+2
+
+* Fix constant evaluation analyzer error in `shelf_unmodifiable_map.dart`.
+
 ## 0.7.3+1
 
 * Updated SDK version to 2.0.0-dev.55.0.

--- a/lib/src/shelf_unmodifiable_map.dart
+++ b/lib/src/shelf_unmodifiable_map.dart
@@ -54,7 +54,7 @@ class ShelfUnmodifiableMap<V> extends UnmodifiableMapView<String, V> {
 class _EmptyShelfUnmodifiableMap<V> extends MapView<String, V>
     implements ShelfUnmodifiableMap<V> {
   bool get _ignoreKeyCase => true;
-  const _EmptyShelfUnmodifiableMap() : super(const {});
+  const _EmptyShelfUnmodifiableMap() : super(const <String,Null>{});
 
   // Override modifier methods that care about the type of key they use so that
   // when V is Null, they throw UnsupportedErrors instead of type errors.

--- a/lib/src/shelf_unmodifiable_map.dart
+++ b/lib/src/shelf_unmodifiable_map.dart
@@ -54,7 +54,7 @@ class ShelfUnmodifiableMap<V> extends UnmodifiableMapView<String, V> {
 class _EmptyShelfUnmodifiableMap<V> extends MapView<String, V>
     implements ShelfUnmodifiableMap<V> {
   bool get _ignoreKeyCase => true;
-  const _EmptyShelfUnmodifiableMap() : super(const <String,Null>{});
+  const _EmptyShelfUnmodifiableMap() : super(const <String, Null>{});
 
   // Override modifier methods that care about the type of key they use so that
   // when V is Null, they throw UnsupportedErrors instead of type errors.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf
-version: 0.7.3+1
+version: 0.7.3+2
 author: Dart Team <misc@dartlang.org>
 description: Web Server Middleware for Dart
 homepage: https://github.com/dart-lang/shelf


### PR DESCRIPTION
…yzer

This fixes a "Evaluation of this constant expression throws an exception" analyzer error in 2.0.0-dev.64.1.