### PR TITLE
Update shelf_io.dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
+## 0.7.4
+
+* Allow passing `shared` parameter to underlying `HttpServer.bind` calls via `shelf_io.serve`
+
 ## 0.7.3+3
 
 * Set max SDK version to `<3.0.0`, and adjust other dependencies.
-* Allow passing `shared` parameter to underlying `HttpServer.bind` calls via `shelf_io.serve`
 
 ## 0.7.3+2
 

--- a/lib/shelf_io.dart
+++ b/lib/shelf_io.dart
@@ -38,7 +38,7 @@ export 'src/io_server.dart';
 /// If a [securityContext] is provided an HTTPS server will be started.
 ////
 /// See the documentation for [HttpServer.bind] and [HttpServer.bindSecure]
-/// for more details on [address], [port], and [backlog].
+/// for more details on [address], [port], [backlog], and [shared].
 Future<HttpServer> serve(Handler handler, address, int port,
     {SecurityContext securityContext, int backlog, bool shared = false}) async {
   backlog ??= 0;

--- a/lib/shelf_io.dart
+++ b/lib/shelf_io.dart
@@ -40,7 +40,7 @@ export 'src/io_server.dart';
 /// See the documentation for [HttpServer.bind] and [HttpServer.bindSecure]
 /// for more details on [address], [port], and [backlog].
 Future<HttpServer> serve(Handler handler, address, int port,
-    {SecurityContext securityContext, int backlog, bool shared}) async {
+    {SecurityContext securityContext, int backlog, bool shared = false}) async {
   backlog ??= 0;
   HttpServer server = await (securityContext == null
       ? HttpServer.bind(address, port, backlog: backlog, shared: shared)

--- a/lib/shelf_io.dart
+++ b/lib/shelf_io.dart
@@ -40,12 +40,12 @@ export 'src/io_server.dart';
 /// See the documentation for [HttpServer.bind] and [HttpServer.bindSecure]
 /// for more details on [address], [port], and [backlog].
 Future<HttpServer> serve(Handler handler, address, int port,
-    {SecurityContext securityContext, int backlog}) async {
+    {SecurityContext securityContext, int backlog, bool shared}) async {
   backlog ??= 0;
   HttpServer server = await (securityContext == null
-      ? HttpServer.bind(address, port, backlog: backlog)
+      ? HttpServer.bind(address, port, backlog: backlog, shared: shared)
       : HttpServer.bindSecure(address, port, securityContext,
-          backlog: backlog));
+          backlog: backlog, shared: shared));
   serveRequests(server, handler);
   return server;
 }


### PR DESCRIPTION
Pass `shared` parameter through to `HttpServer.bind` and `HttpServer.bindSecure` (i.e., to enable port sharing across separate isolates)