### PR TITLE
Return the correct HTTP status code for badly formatted requests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.5.
+
+* Return the correct HTTP status code for badly formatted requests.
+
 ## 0.7.4+1
 
 * Allow `stream_channel` version 2.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.7.5.
+## 0.7.5
 
 * Return the correct HTTP status code for badly formatted requests.
 

--- a/lib/shelf_io.dart
+++ b/lib/shelf_io.dart
@@ -74,8 +74,10 @@ Future handleRequest(HttpRequest request, Handler handler) async {
   try {
     shelfRequest = _fromHttpRequest(request);
   } catch (error, stackTrace) {
-    var response =
-        _logTopLevelError('Error parsing request.\n$error', stackTrace);
+    _logTopLevelError('Error parsing request.\n$error', stackTrace);
+    final response = Response(400,
+        body: 'Bad Request',
+        headers: {HttpHeaders.contentTypeHeader: 'text/plain'});
     await _writeResponse(response, request.response);
     return;
   }
@@ -203,10 +205,11 @@ Response _logError(Request request, String message, [StackTrace stackTrace]) {
   buffer.writeln();
   buffer.write(message);
 
-  return _logTopLevelError(buffer.toString(), stackTrace);
+  _logTopLevelError(buffer.toString(), stackTrace);
+  return Response.internalServerError();
 }
 
-Response _logTopLevelError(String message, [StackTrace stackTrace]) {
+void _logTopLevelError(String message, [StackTrace stackTrace]) {
   var chain = Chain.current();
   if (stackTrace != null) {
     chain = Chain.forTrace(stackTrace);
@@ -218,5 +221,4 @@ Response _logTopLevelError(String message, [StackTrace stackTrace]) {
   stderr.writeln('ERROR - ${DateTime.now()}');
   stderr.writeln(message);
   stderr.writeln(chain);
-  return Response.internalServerError();
 }

--- a/lib/shelf_io.dart
+++ b/lib/shelf_io.dart
@@ -73,16 +73,15 @@ Future handleRequest(HttpRequest request, Handler handler) async {
   Request shelfRequest;
   try {
     shelfRequest = _fromHttpRequest(request);
-  } on UriArgumentError catch (error, stackTrace) {
-    _logTopLevelError('Error parsing request.\n$error', stackTrace);
-    final response = Response(400,
-        body: 'Bad Request',
-        headers: {HttpHeaders.contentTypeHeader: 'text/plain'});
-    await _writeResponse(response, request.response);
-    return;
   } catch (error, stackTrace) {
+    final isClientError = error is ArgumentError &&
+        (error.name == 'method' || error.name == 'requestedUri');
     _logTopLevelError('Error parsing request.\n$error', stackTrace);
-    final response = Response.internalServerError();
+    final response = isClientError
+        ? Response(400,
+            body: 'Bad Request',
+            headers: {HttpHeaders.contentTypeHeader: 'text/plain'})
+        : Response.internalServerError();
     await _writeResponse(response, request.response);
     return;
   }

--- a/lib/shelf_io.dart
+++ b/lib/shelf_io.dart
@@ -86,6 +86,7 @@ Future handleRequest(HttpRequest request, Handler handler) async {
       final response = Response.internalServerError();
       await _writeResponse(response, request.response);
     }
+    return;
   } catch (error, stackTrace) {
     _logTopLevelError('Error parsing request.\n$error', stackTrace);
     final response = Response.internalServerError();

--- a/lib/shelf_io.dart
+++ b/lib/shelf_io.dart
@@ -73,11 +73,16 @@ Future handleRequest(HttpRequest request, Handler handler) async {
   Request shelfRequest;
   try {
     shelfRequest = _fromHttpRequest(request);
-  } catch (error, stackTrace) {
+  } on UriArgumentError catch (error, stackTrace) {
     _logTopLevelError('Error parsing request.\n$error', stackTrace);
     final response = Response(400,
         body: 'Bad Request',
         headers: {HttpHeaders.contentTypeHeader: 'text/plain'});
+    await _writeResponse(response, request.response);
+    return;
+  } catch (error, stackTrace) {
+    _logTopLevelError('Error parsing request.\n$error', stackTrace);
+    final response = Response.internalServerError();
     await _writeResponse(response, request.response);
     return;
   }

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -167,20 +167,24 @@ class Request extends Message {
         this.handlerPath = _computeHandlerPath(requestedUri, handlerPath, url),
         this._onHijack = onHijack,
         super(body, encoding: encoding, headers: headers, context: context) {
-    if (method.isEmpty) throw UriArgumentError('method cannot be empty.');
+    if (method.isEmpty)
+      throw ArgumentError.value(method, 'method', 'cannot be empty.');
 
     if (!requestedUri.isAbsolute) {
-      throw UriArgumentError(
-          'requestedUri "$requestedUri" must be an absolute URL.');
+      throw ArgumentError.value(
+          requestedUri, 'requestedUri', 'must be an absolute URL.');
     }
 
     if (requestedUri.fragment.isNotEmpty) {
-      throw UriArgumentError(
-          'requestedUri "$requestedUri" may not have a fragment.');
+      throw ArgumentError.value(
+          requestedUri, 'requestedUri', 'may not have a fragment.');
     }
 
     if (this.handlerPath + this.url.path != this.requestedUri.path) {
-      throw UriArgumentError('handlerPath "$handlerPath" and url "$url" must '
+      throw ArgumentError.value(
+          requestedUri,
+          'requestedUri',
+          'handlerPath "$handlerPath" and url "$url" must '
           'combine to equal requestedUri path "${requestedUri.path}".');
     }
   }
@@ -354,9 +358,4 @@ String _computeHandlerPath(Uri requestedUri, String handlerPath, Uri url) {
   } else {
     return '/';
   }
-}
-
-/// [ArgumentError] for [Uri] parsing and validation.
-class UriArgumentError extends ArgumentError {
-  UriArgumentError(String message) : super(message);
 }

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -167,20 +167,20 @@ class Request extends Message {
         this.handlerPath = _computeHandlerPath(requestedUri, handlerPath, url),
         this._onHijack = onHijack,
         super(body, encoding: encoding, headers: headers, context: context) {
-    if (method.isEmpty) throw ArgumentError('method cannot be empty.');
+    if (method.isEmpty) throw UriArgumentError('method cannot be empty.');
 
     if (!requestedUri.isAbsolute) {
-      throw ArgumentError(
+      throw UriArgumentError(
           'requestedUri "$requestedUri" must be an absolute URL.');
     }
 
     if (requestedUri.fragment.isNotEmpty) {
-      throw ArgumentError(
+      throw UriArgumentError(
           'requestedUri "$requestedUri" may not have a fragment.');
     }
 
     if (this.handlerPath + this.url.path != this.requestedUri.path) {
-      throw ArgumentError('handlerPath "$handlerPath" and url "$url" must '
+      throw UriArgumentError('handlerPath "$handlerPath" and url "$url" must '
           'combine to equal requestedUri path "${requestedUri.path}".');
     }
   }
@@ -354,4 +354,9 @@ String _computeHandlerPath(Uri requestedUri, String handlerPath, Uri url) {
   } else {
     return '/';
   }
+}
+
+/// [ArgumentError] for [Uri] parsing and validation.
+class UriArgumentError extends ArgumentError {
+  UriArgumentError(String message) : super(message);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf
-version: 0.7.4+1
+version: 0.7.5-dev
 description: >-
   A model for web server middleware that encourages composition and easy reuse
 author: Dart Team <misc@dartlang.org>

--- a/test/shelf_io_test.dart
+++ b/test/shelf_io_test.dart
@@ -267,7 +267,7 @@ void main() {
     expect(response.body, 'Hello from /');
   });
 
-  test('a bad HTTP request results in a 400 response', () async {
+  test('a bad HTTP host request results in a 500 response', () async {
     await _scheduleServer(syncHandler);
 
     var socket = await Socket.connect('localhost', _serverPort);
@@ -275,6 +275,22 @@ void main() {
     try {
       socket.write('GET / HTTP/1.1\r\n');
       socket.write('Host: ^^super bad !@#host\r\n');
+      socket.write('\r\n');
+    } finally {
+      await socket.close();
+    }
+
+    expect(
+        await utf8.decodeStream(socket), contains('500 Internal Server Error'));
+  });
+
+  test('a bad HTTP URL request results in a 400 response', () async {
+    await _scheduleServer(syncHandler);
+    final socket = await Socket.connect('localhost', _serverPort);
+
+    try {
+      socket.write('GET /#/ HTTP/1.1\r\n');
+      socket.write('Host: localhost\r\n');
       socket.write('\r\n');
     } finally {
       await socket.close();

--- a/test/shelf_io_test.dart
+++ b/test/shelf_io_test.dart
@@ -267,7 +267,7 @@ void main() {
     expect(response.body, 'Hello from /');
   });
 
-  test('a bad HTTP request results in a 500 response', () async {
+  test('a bad HTTP request results in a 400 response', () async {
     await _scheduleServer(syncHandler);
 
     var socket = await Socket.connect('localhost', _serverPort);
@@ -280,8 +280,7 @@ void main() {
       await socket.close();
     }
 
-    expect(
-        await utf8.decodeStream(socket), contains('500 Internal Server Error'));
+    expect(await utf8.decodeStream(socket), contains('400 Bad Request'));
   });
 
   group('date header', () {


### PR DESCRIPTION
A bad request should return 400 and not 500.
Ref: https://github.com/dart-lang/pub-dartlang-dart/issues/2081