### PR TITLE
Prepare for upcoming change to HttpRequest and HttpClientResponse

### DIFF
--- a/test/shelf_io_test.dart
+++ b/test/shelf_io_test.dart
@@ -510,7 +510,8 @@ void main() {
 
       var response = await req.close();
       expect(response.statusCode, HttpStatus.ok);
-      expect(await response.transform(utf8.decoder).single, 'Hello from /');
+      expect(await response.cast<List<int>>().transform(utf8.decoder).single,
+          'Hello from /');
     });
 
     test('secure async handler returns a value to the client', () async {
@@ -519,7 +520,8 @@ void main() {
       var req = await _scheduleSecureGet();
       var response = await req.close();
       expect(response.statusCode, HttpStatus.ok);
-      expect(await response.transform(utf8.decoder).single, 'Hello from /');
+      expect(await response.cast<List<int>>().transform(utf8.decoder).single,
+          'Hello from /');
     });
   });
 }


### PR DESCRIPTION
An upcoming change to the Dart SDK will change `HttpRequest` and
`HttpClientResponse` from implementing `Stream<List<int>>` to
implementing `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900