### PR TITLE
Remove an unnecessary "newFuture" utility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: dart
 
 dart:
-  - 2.0.0
+  - 2.1.0
   - dev
 
 dart_task:

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -275,7 +275,7 @@ class _OnHijack {
   void run(void Function(StreamChannel<List<int>>) callback) {
     if (called) throw StateError('This request has already been hijacked.');
     called = true;
-    newFuture(() => _callback(callback));
+    Future.microtask(() => _callback(callback));
   }
 }
 

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -8,11 +8,6 @@ import 'package:collection/collection.dart';
 
 import 'shelf_unmodifiable_map.dart';
 
-/// Like [new Future], but avoids around issue 11911 by using [new Future.value]
-/// under the covers.
-Future newFuture(void Function() callback) =>
-    Future.value().then((_) => callback());
-
 /// Run [callback] and capture any errors that would otherwise be top-leveled.
 ///
 /// If [this] is called in a non-root error zone, it will just run [callback]

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/shelf
 
 environment:
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: ">=2.1.0 <3.0.0"
 
 dependencies:
   async: ^2.0.7


### PR DESCRIPTION
This behaves the same as `Future.microtask`.

Bump the minimum version of the SDK to on which includes `Future` in
`dart:core`.