### PR TITLE
Small doc and style cleanup

### DIFF
--- a/lib/src/message.dart
+++ b/lib/src/message.dart
@@ -12,7 +12,7 @@ import 'body.dart';
 import 'shelf_unmodifiable_map.dart';
 import 'util.dart';
 
-Body getBody(Message message) => message._body;
+Body extractBody(Message message) => message._body;
 
 /// The default set of headers for a message created with no body and no
 /// explicit headers.
@@ -153,7 +153,7 @@ Map<String, String> _adjustHeaders(Map<String, String> headers, Body body) {
   var sameEncoding = _sameEncoding(headers, body);
   if (sameEncoding) {
     if (body.contentLength == null ||
-        getHeader(headers, 'content-length') == body.contentLength.toString()) {
+        findHeader(headers, 'content-length') == body.contentLength.toString()) {
       return headers ?? const ShelfUnmodifiableMap.empty();
     } else if (body.contentLength == 0 &&
         (headers == null || headers.isEmpty)) {
@@ -190,7 +190,7 @@ Map<String, String> _adjustHeaders(Map<String, String> headers, Body body) {
 bool _sameEncoding(Map<String, String> headers, Body body) {
   if (body.encoding == null) return true;
 
-  var contentType = getHeader(headers, 'content-type');
+  var contentType = findHeader(headers, 'content-type');
   if (contentType == null) return false;
 
   var charset = MediaType.parse(contentType).parameters['charset'];

--- a/lib/src/message.dart
+++ b/lib/src/message.dart
@@ -153,7 +153,7 @@ Map<String, String> _adjustHeaders(Map<String, String> headers, Body body) {
   var sameEncoding = _sameEncoding(headers, body);
   if (sameEncoding) {
     if (body.contentLength == null ||
-        findHeader(headers, 'content-length') == body.contentLength.toString()) {
+        findHeader(headers, 'content-length') == '${body.contentLength}') {
       return headers ?? const ShelfUnmodifiableMap.empty();
     } else if (body.contentLength == 0 &&
         (headers == null || headers.isEmpty)) {

--- a/lib/src/middleware/logger.dart
+++ b/lib/src/middleware/logger.dart
@@ -28,7 +28,7 @@ Middleware logRequests({void Function(String message, bool isError) logger}) =>
         var watch = Stopwatch()..start();
 
         return Future.sync(() => innerHandler(request)).then((response) {
-          var msg = _getMessage(startTime, response.statusCode,
+          var msg = _message(startTime, response.statusCode,
               request.requestedUri, request.method, watch.elapsed);
 
           logger(msg, false);
@@ -37,7 +37,7 @@ Middleware logRequests({void Function(String message, bool isError) logger}) =>
         }, onError: (error, StackTrace stackTrace) {
           if (error is HijackException) throw error;
 
-          var msg = _getErrorMessage(startTime, request.requestedUri,
+          var msg = _errorMessage(startTime, request.requestedUri,
               request.method, watch.elapsed, error, stackTrace);
 
           logger(msg, true);
@@ -51,7 +51,7 @@ String _formatQuery(String query) {
   return query == '' ? '' : '?$query';
 }
 
-String _getMessage(DateTime requestTime, int statusCode, Uri requestedUri,
+String _message(DateTime requestTime, int statusCode, Uri requestedUri,
     String method, Duration elapsedTime) {
   return '${requestTime.toIso8601String()} '
       '${elapsedTime.toString().padLeft(15)} '
@@ -59,7 +59,7 @@ String _getMessage(DateTime requestTime, int statusCode, Uri requestedUri,
       '${requestedUri.path}${_formatQuery(requestedUri.query)}';
 }
 
-String _getErrorMessage(DateTime requestTime, Uri requestedUri, String method,
+String _errorMessage(DateTime requestTime, Uri requestedUri, String method,
     Duration elapsedTime, Object error, StackTrace stack) {
   var chain = Chain.current();
   if (stack != null) {

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -11,12 +11,7 @@ import 'hijack_exception.dart';
 import 'message.dart';
 import 'util.dart';
 
-/// A callback provided by a Shelf adapter that's used by [Request.hijack] to
-/// provide a [HijackCallback] with a socket.
-typedef _OnHijackCallback = void Function(
-    void Function(StreamChannel<List<int>> channel) callback);
-
-/// Represents an HTTP request to be processed by a Shelf application.
+/// An HTTP request to be processed by a Shelf application.
 class Request extends Message {
   /// The URL path from the current handler to the requested resource, relative
   /// to [handlerPath], plus any query parameters.
@@ -222,7 +217,7 @@ class Request extends Message {
     headers = updateMap(this.headers, headers);
     context = updateMap(this.context, context);
 
-    body ??= getBody(this);
+    body ??= extractBody(this);
 
     var handlerPath = this.handlerPath;
     if (path != null) handlerPath += path;
@@ -258,13 +253,10 @@ class Request extends Message {
   }
 }
 
-/// A class containing a callback for [Request.hijack] that also tracks whether
-/// the callback has been called.
+/// A callback for [Request.hijack] and tracking of whether it has been called.
 class _OnHijack {
-  /// The callback.
-  final _OnHijackCallback _callback;
+  final void Function(void Function(StreamChannel<List<int>>)) _callback;
 
-  /// Whether [this] has been called.
   bool called = false;
 
   _OnHijack(this._callback);

--- a/lib/src/response.dart
+++ b/lib/src/response.dart
@@ -311,7 +311,7 @@ class Response extends Message {
     headers = updateMap(this.headers, headers);
     context = updateMap(this.context, context);
 
-    body ??= getBody(this);
+    body ??= extractBody(this);
 
     return Response(statusCode, body: body, headers: headers, context: context);
   }

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -49,7 +49,7 @@ Map<String, String> addHeader(
 ///
 /// This works even if [headers] is `null`, or if it's not yet a
 /// case-insensitive map.
-String getHeader(Map<String, String> headers, String name) {
+String findHeader(Map<String, String> headers, String name) {
   if (headers == null) return null;
   if (headers is ShelfUnmodifiableMap) return headers[name];
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,6 @@ name: shelf
 version: 0.7.6-dev
 description: >-
   A model for web server middleware that encourages composition and easy reuse
-author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/shelf
 
 environment:


### PR DESCRIPTION
Fix some docs to be noun phrases for classes.

Remove some docs that are wholly redundant against the signature.

Remove an unnecessary private typedef.

Rename some methods that start with "get".