### PR TITLE
Updated docs to reflect that Response.change(body: null) will not work

### DIFF
--- a/lib/src/response.dart
+++ b/lib/src/response.dart
@@ -304,7 +304,7 @@ class Response extends Message {
   /// in the copied [Response] unchanged.
   ///
   /// [body] is the request body. It may be either a [String], a [List<int>], a
-  /// [Stream<List<int>>], or `null` to indicate no body.
+  /// [Stream<List<int>>], or `<int>[]` (empty list) to indicate no body.
   @override
   Response change(
       {Map<String, String> headers, Map<String, Object> context, body}) {


### PR DESCRIPTION
Passing `null` into `Response.change(body: null)` does not create a new `Response` with no body as the documentation would have one think.

Passing an empty list [should create the same result as passing null](https://github.com/dart-lang/shelf/blob/master/lib/src/body.dart#L40-L41).

I did consider fixing the code as follows, but I think that might be a bit too fancy :)

```dart
  @override
  Response change({
    Map<String, String> headers,
    Map<String, Object> context,
    body = #_notChanged,
  }) {
    headers = updateMap(this.headers, headers);
    context = updateMap(this.context, context);

    if (body == #_notChanged) {
      body = extractBody(this);
    }

    return Response(statusCode, body: body, headers: headers, context: context);
  }
```