### PR TITLE
Document that Request.ifModifiedSince throws FormatException

### DIFF
--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -68,6 +68,9 @@ class Request extends Message {
   ///
   /// This is parsed from the If-Modified-Since header in [headers]. If
   /// [headers] doesn't have an If-Modified-Since header, this will be `null`.
+  ///
+  /// Throws [FormatException], if incoming HTTP request has an invalid
+  /// If-Modified-Since header.
   DateTime get ifModifiedSince {
     if (_ifModifiedSinceCache != null) return _ifModifiedSinceCache;
     if (!headers.containsKey('if-modified-since')) return null;


### PR DESCRIPTION
It's a bit surprising that `Request.ifModifiedSince` throws `FormatException` if the incoming request is invalid.

We could also return `null`. But this has the downside of building a server that accepts invalid requests. The problem with accepting invalid requests is that you're going to break your users if you fix such a bug later.

Ideally, we should throw an exception that is caught and converted to `400` at some higher level.
But this would be a new way of structuring apps in `shelf`, so we should probably consider this in detail before we jump on the idea.