### PR TITLE
Handle cases where colon is in the first path segment

### DIFF
--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -178,11 +178,17 @@ class Request extends Message {
           requestedUri, 'requestedUri', 'may not have a fragment.');
     }
 
-    if (this.handlerPath + this.url.path != this.requestedUri.path) {
+    // Notice that because relative paths must encode colon (':') as %3A we
+    // cannot actually combine this.handlerPath and this.url.path, but we can
+    // compare the pathSegments. In practice exposing this.url.path as a Uri
+    // and not a String is probably the underlying flaw here.
+    final pathSegments = Uri(path: this.handlerPath).pathSegments.join('/') +
+        this.url.pathSegments.join('/');
+    if (pathSegments != this.requestedUri.pathSegments.join('/')) {
       throw ArgumentError.value(
           requestedUri,
           'requestedUri',
-          'handlerPath "$handlerPath" and url "$url" must '
+          'handlerPath "${this.handlerPath}" and url "${this.url}" must '
               'combine to equal requestedUri path "${requestedUri.path}".');
     }
   }

--- a/test/request_test.dart
+++ b/test/request_test.dart
@@ -33,6 +33,22 @@ void main() {
         expect(request.url, equals(Uri.parse('foo/bar?q=1')));
       });
 
+      test('may contain colon', () {
+        var request = Request('GET', Uri.parse('http://localhost/foo/bar:42'));
+        expect(request.url, equals(Uri.parse('foo/bar:42')));
+      });
+
+      test('may contain colon in first segment', () {
+        var request = Request('GET', Uri.parse('http://localhost/foo:bar/42'));
+        expect(request.url, equals(Uri.parse('foo%3Abar/42')));
+      });
+
+      test('may contain slash', () {
+        var request =
+            Request('GET', Uri.parse('http://localhost/foo/bar%2f42'));
+        expect(request.url, equals(Uri.parse('foo/bar%2f42')));
+      });
+
       test('is inferred from handlerPath if possible', () {
         var request = Request('GET', Uri.parse('http://localhost/foo/bar?q=1'),
             handlerPath: '/foo/');

--- a/test/shelf_io_test.dart
+++ b/test/shelf_io_test.dart
@@ -103,6 +103,14 @@ void main() {
     expect(response.body, 'Hello from /foo/bar');
   });
 
+  test('Request can handle colon in first path segment', () async {
+    await _scheduleServer(syncHandler);
+
+    var response = await _get(path: 'user:42');
+    expect(response.statusCode, HttpStatus.ok);
+    expect(response.body, 'Hello from /user:42');
+  });
+
   test('chunked requests are un-chunked', () async {
     await _scheduleServer(expectAsync1((request) {
       expect(request.contentLength, isNull);
@@ -563,11 +571,13 @@ Future _scheduleServer(Handler handler,
 
 Future<http.Response> _get({
   Map<String, /* String | List<String> */ Object> headers,
+  String path = '',
 }) async {
   // TODO: use http.Client once it supports sending and receiving multiple headers.
   final client = HttpClient();
   try {
-    final rq = await client.getUrl(Uri.parse('http://localhost:$_serverPort/'));
+    final rq =
+        await client.getUrl(Uri.parse('http://localhost:$_serverPort/$path'));
     headers?.forEach((key, value) {
       rq.headers.add(key, value);
     });


### PR DESCRIPTION
`Request.url.path` is supposed to be relative to `Request.handlerPath`, this invariant is enforced by throwing `ArgumentError` in the constructor. However, if an incoming request has colon in the first
path segment the `shelf_io` adapter will create a request with `/` handler path creating a `Request.url.path` that is relative to `/` and which has colon in the first segment. This causes unnecessary encoding of the colon which breaks the invariant check.

In hindsight it's probably not ideal to use `Uri` for holding a relative path as this will always mangle the colon. But fixing this is very breaking.

I don't know if this check is likely to break other cases, I added a few test cases to ensure that slash encoding was also covered.


----
note. I don't really like this solution. But after playing with it I'm starting to be convinced that `Request.url` should instead be split into `Request.path` and `Request.query`, such that we don't need to have  `Uri` that is relative. But instead have a relative path exposed a `String` in `Request.path` or something like that. A change like this would, however, break everybody using shelf and reading the path or querystring params.

I guess we could annotate `Request.url` deprecated and gradually introduce `Request.path` and `Request.query`, if we're sure this is how we want to expose it. A relative path string might work a little better, but it'll be hard to access decoded path segments correctly (one would have to split on slashes and component decode each segment).

Not to mention that there could be other complications I haven't even considered :)