### PR TITLE
Fix failure test with breaking HTTP Header change

### DIFF
--- a/test/shelf_io_test.dart
+++ b/test/shelf_io_test.dart
@@ -221,7 +221,9 @@ void main() {
 
     var response = await _post(body: 'Hello');
     expect(response.statusCode, HttpStatus.notFound);
-    expect(response.headers['date'], 'Mon, 23 May 2005 22:38:34 GMT');
+    // TODO: after https://dart-review.googlesource.com/c/sdk/+/143081 lands,
+    // uncomment the following line.
+    // expect(response.headers['Date'], 'Mon, 23 May 2005 22:38:34 GMT');
     expect(
         response.stream.bytesToString(), completion(equals('Hello, world!')));
   });

--- a/test/shelf_io_test.dart
+++ b/test/shelf_io_test.dart
@@ -209,7 +209,7 @@ void main() {
         expect(channel.stream.first, completion(equals('Hello'.codeUnits)));
 
         channel.sink.add(('HTTP/1.1 404 Not Found\r\n'
-                'Date: Mon, 23 May 2005 22:38:34 GMT\r\n'
+                'date: Mon, 23 May 2005 22:38:34 GMT\r\n'
                 'Content-Length: 13\r\n'
                 '\r\n'
                 'Hello, world!')
@@ -221,9 +221,7 @@ void main() {
 
     var response = await _post(body: 'Hello');
     expect(response.statusCode, HttpStatus.notFound);
-    // TODO: after https://dart-review.googlesource.com/c/sdk/+/143081 lands,
-    // uncomment the following line.
-    // expect(response.headers['Date'], 'Mon, 23 May 2005 22:38:34 GMT');
+    expect(response.headers['date'], 'Mon, 23 May 2005 22:38:34 GMT');
     expect(
         response.stream.bytesToString(), completion(equals('Hello, world!')));
   });


### PR DESCRIPTION
This is a follow-up cl(https://dart-review.googlesource.com/c/sdk/+/143081) for previous HttpHeaders casing issue.

With this change, HttpParser will preserve the casing of HttpHeader fields name.

To avoid the breakage, I comment out the line once the cl lands. It can be added back.