### PR TITLE
Supporting multiple header values in Request and Response.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## 0.7.6-dev
 
+* Supports multiple header values in `Request` and `Response`:
+  * `headersAll` field contains all the header values 
+  * `headers` field contains the same values as previously (appending values with `,`)
+  * `headers` parameter in the constructor and in the `.change()` method accepts
+    both `String` and `List<String>` values.
+
 ## 0.7.5
 
 * Return the correct HTTP status code for badly formatted requests.

--- a/lib/shelf_io.dart
+++ b/lib/shelf_io.dart
@@ -130,11 +130,9 @@ Future handleRequest(HttpRequest request, Handler handler) async {
 
 /// Creates a new [Request] from the provided [HttpRequest].
 Request _fromHttpRequest(HttpRequest request) {
-  var headers = <String, String>{};
+  var headers = <String, List<String>>{};
   request.headers.forEach((k, v) {
-    // Multiple header values are joined with commas.
-    // See http://tools.ietf.org/html/draft-ietf-httpbis-p1-messaging-21#page-22
-    headers[k] = v.join(',');
+    headers[k] = v;
   });
 
   // Remove the Transfer-Encoding header per the adapter requirements.
@@ -168,7 +166,7 @@ Future _writeResponse(Response response, HttpResponse httpResponse) {
   // necessary.
   httpResponse.headers.chunkedTransferEncoding = false;
 
-  response.headers.forEach((header, value) {
+  response.headersAll.forEach((header, value) {
     if (value == null) return;
     httpResponse.headers.set(header, value);
   });

--- a/lib/src/headers.dart
+++ b/lib/src/headers.dart
@@ -1,0 +1,57 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:collection';
+
+import 'package:http_parser/http_parser.dart';
+import 'package:shelf/src/util.dart';
+
+final _emptyHeaders = Headers._empty();
+
+/// Unmodifiable, key-insensitive header map.
+class Headers extends UnmodifiableMapView<String, List<String>> {
+  Map<String, String> _singeValues;
+
+  factory Headers.from(Map<String, List<String>> values) {
+    if (values == null || values.isEmpty) {
+      return _emptyHeaders;
+    } else if (values is Headers) {
+      return values;
+    } else {
+      return Headers._(values);
+    }
+  }
+
+  Headers._(Map<String, List<String>> values)
+      : super(
+          CaseInsensitiveMap<List<String>>.from(
+            Map<String, List<String>>.fromEntries(
+              values.entries
+                  .where((e) => e.value != null && e.value.isNotEmpty)
+                  .map(
+                    (e) => MapEntry<String, List<String>>(
+                      e.key,
+                      List.unmodifiable(e.value),
+                    ),
+                  ),
+            ),
+          ),
+        );
+
+  Headers._empty() : super(<String, List<String>>{});
+  factory Headers.empty() => _emptyHeaders;
+
+  Map<String, String> get singleValues {
+    return _singeValues ??= _SingleValueHeaders(
+      CaseInsensitiveMap<String>.from(
+        map((key, value) =>
+            MapEntry<String, String>(key, joinHeaderValues(value))),
+      ),
+    );
+  }
+}
+
+class _SingleValueHeaders extends UnmodifiableMapView<String, String> {
+  _SingleValueHeaders(Map<String, String> map) : super(map);
+}

--- a/lib/src/message.dart
+++ b/lib/src/message.dart
@@ -26,6 +26,7 @@ abstract class Message {
   final Headers _headers;
 
   /// The HTTP headers.
+  /// The keys in this Map are normalized, and access is case-insensitive.
   ///
   /// If a header occurs more than once in the query string, they are mapped to
   /// by concatenating them with a comma.
@@ -34,6 +35,7 @@ abstract class Message {
   Map<String, String> get headers => _headers.singleValues;
 
   /// The HTTP headers with multiple values.
+  /// The keys in this Map are normalized, and access is case-insensitive.
   ///
   /// If a header occurs only once, its value is a singleton list.
   /// If a header occurs with no value, the empty string is used as the value

--- a/lib/src/message.dart
+++ b/lib/src/message.dart
@@ -79,7 +79,7 @@ abstract class Message {
   /// Content-Type header, it will be set to "application/octet-stream".
   Message(body,
       {Encoding encoding,
-      Map<String, /* String | List<String> */ dynamic> headers,
+      Map<String, /* String | List<String> */ Object> headers,
       Map<String, Object> context})
       : this._withBody(Body(body, encoding), headers, context);
 

--- a/lib/src/message.dart
+++ b/lib/src/message.dart
@@ -9,6 +9,7 @@ import 'package:collection/collection.dart';
 import 'package:http_parser/http_parser.dart';
 
 import 'body.dart';
+import 'headers.dart';
 import 'shelf_unmodifiable_map.dart';
 import 'util.dart';
 
@@ -16,15 +17,30 @@ Body extractBody(Message message) => message._body;
 
 /// The default set of headers for a message created with no body and no
 /// explicit headers.
-final _defaultHeaders =
-    ShelfUnmodifiableMap<String>({'content-length': '0'}, ignoreKeyCase: true);
+final _defaultHeaders = Headers.from({
+  'content-length': ['0'],
+});
 
 /// Represents logic shared between [Request] and [Response].
 abstract class Message {
+  final Headers _headers;
+
   /// The HTTP headers.
   ///
-  /// The value is immutable.
-  final Map<String, String> headers;
+  /// If a header occurs more than once in the query string, they are mapped to
+  /// by concatenating them with a comma.
+  ///
+  /// The returned map is unmodifiable.
+  Map<String, String> get headers => _headers.singleValues;
+
+  /// The HTTP headers with multiple values.
+  ///
+  /// If a header occurs only once, its value is a singleton list.
+  /// If a header occurs with no value, the empty string is used as the value
+  /// for that occurrence.
+  ///
+  /// The returned map and the lists it contains are unmodifiable.
+  Map<String, List<String>> get headersAll => _headers;
 
   /// Extra context that can be used by for middleware and handlers.
   ///
@@ -63,14 +79,21 @@ abstract class Message {
   /// Content-Type header, it will be set to "application/octet-stream".
   Message(body,
       {Encoding encoding,
-      Map<String, String> headers,
+      Map<String, /* String | List<String> */ dynamic> headers,
       Map<String, Object> context})
-      : this._(Body(body, encoding), headers, context);
+      : this._withBody(Body(body, encoding), headers, context);
 
-  Message._(Body body, Map<String, String> headers, Map<String, Object> context)
+  Message._withBody(
+      Body body, Map<String, dynamic> headers, Map<String, Object> context)
+      : this._withHeadersAll(
+            body,
+            Headers.from(_adjustHeaders(expandToHeadersAll(headers), body)),
+            context);
+
+  Message._withHeadersAll(
+      Body body, Headers headers, Map<String, Object> context)
       : _body = body,
-        headers = ShelfUnmodifiableMap<String>(_adjustHeaders(headers, body),
-            ignoreKeyCase: true),
+        _headers = headers,
         context = ShelfUnmodifiableMap<Object>(context, ignoreKeyCase: false);
 
   /// The contents of the content-length field in [headers].
@@ -149,12 +172,13 @@ abstract class Message {
 /// Adds information about [encoding] to [headers].
 ///
 /// Returns a new map without modifying [headers].
-Map<String, String> _adjustHeaders(Map<String, String> headers, Body body) {
+Map<String, List<String>> _adjustHeaders(
+    Map<String, List<String>> headers, Body body) {
   var sameEncoding = _sameEncoding(headers, body);
   if (sameEncoding) {
     if (body.contentLength == null ||
         findHeader(headers, 'content-length') == '${body.contentLength}') {
-      return headers ?? const ShelfUnmodifiableMap.empty();
+      return headers ?? Headers.empty();
     } else if (body.contentLength == 0 &&
         (headers == null || headers.isEmpty)) {
       return _defaultHeaders;
@@ -162,24 +186,26 @@ Map<String, String> _adjustHeaders(Map<String, String> headers, Body body) {
   }
 
   var newHeaders = headers == null
-      ? CaseInsensitiveMap<String>()
-      : CaseInsensitiveMap<String>.from(headers);
+      ? CaseInsensitiveMap<List<String>>()
+      : CaseInsensitiveMap<List<String>>.from(headers);
 
   if (!sameEncoding) {
     if (newHeaders['content-type'] == null) {
-      newHeaders['content-type'] =
-          'application/octet-stream; charset=${body.encoding.name}';
+      newHeaders['content-type'] = [
+        'application/octet-stream; charset=${body.encoding.name}'
+      ];
     } else {
-      var contentType = MediaType.parse(newHeaders['content-type'])
-          .change(parameters: {'charset': body.encoding.name});
-      newHeaders['content-type'] = contentType.toString();
+      final contentType =
+          MediaType.parse(joinHeaderValues(newHeaders['content-type']))
+              .change(parameters: {'charset': body.encoding.name});
+      newHeaders['content-type'] = [contentType.toString()];
     }
   }
 
   if (body.contentLength != null) {
-    var coding = newHeaders['transfer-encoding'];
+    final coding = joinHeaderValues(newHeaders['transfer-encoding']);
     if (coding == null || equalsIgnoreAsciiCase(coding, 'identity')) {
-      newHeaders['content-length'] = body.contentLength.toString();
+      newHeaders['content-length'] = [body.contentLength.toString()];
     }
   }
 
@@ -187,7 +213,7 @@ Map<String, String> _adjustHeaders(Map<String, String> headers, Body body) {
 }
 
 /// Returns whether [headers] declares the same encoding as [body].
-bool _sameEncoding(Map<String, String> headers, Body body) {
+bool _sameEncoding(Map<String, List<String>> headers, Body body) {
   if (body.encoding == null) return true;
 
   var contentType = findHeader(headers, 'content-type');

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -126,7 +126,7 @@ class Request extends Message {
   // TODO(kevmoo) finish documenting the rest of the arguments.
   Request(String method, Uri requestedUri,
       {String protocolVersion,
-      Map<String, /* String | List<String> */ dynamic> headers,
+      Map<String, /* String | List<String> */ Object> headers,
       String handlerPath,
       Uri url,
       body,
@@ -151,7 +151,7 @@ class Request extends Message {
   /// from a changed [Request].
   Request._(this.method, Uri requestedUri,
       {String protocolVersion,
-      Map<String, /* String | List<String> */ dynamic> headers,
+      Map<String, /* String | List<String> */ Object> headers,
       String handlerPath,
       Uri url,
       body,
@@ -213,7 +213,7 @@ class Request extends Message {
   ///     print(request.url);        // => file.html
   @override
   Request change(
-      {Map<String, /* String | List<String> */ dynamic> headers,
+      {Map<String, /* String | List<String> */ Object> headers,
       Map<String, Object> context,
       String path,
       body}) {

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -126,7 +126,7 @@ class Request extends Message {
   // TODO(kevmoo) finish documenting the rest of the arguments.
   Request(String method, Uri requestedUri,
       {String protocolVersion,
-      Map<String, String> headers,
+      Map<String, /* String | List<String> */ dynamic> headers,
       String handlerPath,
       Uri url,
       body,
@@ -151,7 +151,7 @@ class Request extends Message {
   /// from a changed [Request].
   Request._(this.method, Uri requestedUri,
       {String protocolVersion,
-      Map<String, String> headers,
+      Map<String, /* String | List<String> */ dynamic> headers,
       String handlerPath,
       Uri url,
       body,
@@ -213,11 +213,11 @@ class Request extends Message {
   ///     print(request.url);        // => file.html
   @override
   Request change(
-      {Map<String, String> headers,
+      {Map<String, /* String | List<String> */ dynamic> headers,
       Map<String, Object> context,
       String path,
       body}) {
-    headers = updateMap(this.headers, headers);
+    final headersAll = updateMap(this.headersAll, expandToHeadersAll(headers));
     context = updateMap(this.context, context);
 
     body ??= extractBody(this);
@@ -227,7 +227,7 @@ class Request extends Message {
 
     return Request._(method, requestedUri,
         protocolVersion: protocolVersion,
-        headers: headers,
+        headers: headersAll,
         handlerPath: handlerPath,
         body: body,
         context: context,

--- a/lib/src/response.dart
+++ b/lib/src/response.dart
@@ -60,7 +60,7 @@ class Response extends Message {
   /// in [headers] will be set appropriately. If there is no existing
   /// Content-Type header, it will be set to "application/octet-stream".
   Response.ok(body,
-      {Map<String, String> headers,
+      {Map<String, /* String | List<String> */ dynamic> headers,
       Encoding encoding,
       Map<String, Object> context})
       : this(200,
@@ -88,7 +88,7 @@ class Response extends Message {
   /// Content-Type header, it will be set to "application/octet-stream".
   Response.movedPermanently(location,
       {body,
-      Map<String, String> headers,
+      Map<String, /* String | List<String> */ dynamic> headers,
       Encoding encoding,
       Map<String, Object> context})
       : this._redirect(301, location, body, headers, encoding,
@@ -116,7 +116,7 @@ class Response extends Message {
   /// Content-Type header, it will be set to "application/octet-stream".
   Response.found(location,
       {body,
-      Map<String, String> headers,
+      Map<String, /* String | List<String> */ dynamic> headers,
       Encoding encoding,
       Map<String, Object> context})
       : this._redirect(302, location, body, headers, encoding,
@@ -145,15 +145,19 @@ class Response extends Message {
   /// Content-Type header, it will be set to "application/octet-stream".
   Response.seeOther(location,
       {body,
-      Map<String, String> headers,
+      Map<String, /* String | List<String> */ dynamic> headers,
       Encoding encoding,
       Map<String, Object> context})
       : this._redirect(303, location, body, headers, encoding,
             context: context);
 
   /// Constructs a helper constructor for redirect responses.
-  Response._redirect(int statusCode, location, body,
-      Map<String, String> headers, Encoding encoding,
+  Response._redirect(
+      int statusCode,
+      location,
+      body,
+      Map<String, /* String | List<String> */ dynamic> headers,
+      Encoding encoding,
       {Map<String, Object> context})
       : this(statusCode,
             body: body,
@@ -169,7 +173,8 @@ class Response extends Message {
   /// since the last request. It indicates that the resource has not changed and
   /// the old value should be used.
   Response.notModified(
-      {Map<String, String> headers, Map<String, Object> context})
+      {Map<String, /* String | List<String> */ dynamic> headers,
+      Map<String, Object> context})
       : this(304,
             headers: addHeader(headers, 'date', formatHttpDate(DateTime.now())),
             context: context);
@@ -193,7 +198,7 @@ class Response extends Message {
   /// in [headers] will be set appropriately. If there is no existing
   /// Content-Type header, it will be set to "application/octet-stream".
   Response.forbidden(body,
-      {Map<String, String> headers,
+      {Map<String, /* String | List<String> */ dynamic> headers,
       Encoding encoding,
       Map<String, Object> context})
       : this(403,
@@ -222,7 +227,7 @@ class Response extends Message {
   /// in [headers] will be set appropriately. If there is no existing
   /// Content-Type header, it will be set to "application/octet-stream".
   Response.notFound(body,
-      {Map<String, String> headers,
+      {Map<String, /* String | List<String> */ dynamic> headers,
       Encoding encoding,
       Map<String, Object> context})
       : this(404,
@@ -252,7 +257,7 @@ class Response extends Message {
   /// Content-Type header, it will be set to "application/octet-stream".
   Response.internalServerError(
       {body,
-      Map<String, String> headers,
+      Map<String, /* String | List<String> */ dynamic> headers,
       Encoding encoding,
       Map<String, Object> context})
       : this(500,
@@ -281,7 +286,7 @@ class Response extends Message {
   /// Content-Type header, it will be set to "application/octet-stream".
   Response(this.statusCode,
       {body,
-      Map<String, String> headers,
+      Map<String, /* String | List<String> */ dynamic> headers,
       Encoding encoding,
       Map<String, Object> context})
       : super(body, encoding: encoding, headers: headers, context: context) {
@@ -307,13 +312,16 @@ class Response extends Message {
   /// [Stream<List<int>>], or `<int>[]` (empty list) to indicate no body.
   @override
   Response change(
-      {Map<String, String> headers, Map<String, Object> context, body}) {
-    headers = updateMap(this.headers, headers);
+      {Map<String, /* String | List<String> */ dynamic> headers,
+      Map<String, Object> context,
+      body}) {
+    final headersAll = updateMap(this.headersAll, expandToHeadersAll(headers));
     context = updateMap(this.context, context);
 
     body ??= extractBody(this);
 
-    return Response(statusCode, body: body, headers: headers, context: context);
+    return Response(statusCode,
+        body: body, headers: headersAll, context: context);
   }
 }
 
@@ -321,13 +329,15 @@ class Response extends Message {
 ///
 /// Returns a new map without modifying [headers]. This is used to add
 /// content-type information when creating a 500 response with a default body.
-Map<String, String> _adjustErrorHeaders(Map<String, String> headers) {
+Map<String, dynamic> _adjustErrorHeaders(
+    Map<String, /* String | List<String> */ dynamic> headers) {
   if (headers == null || headers['content-type'] == null) {
     return addHeader(headers, 'content-type', 'text/plain');
   }
 
+  final contentTypeValue = expandHeaderValue(headers['content-type']).join(',');
   var contentType =
-      MediaType.parse(headers['content-type']).change(mimeType: 'text/plain');
+      MediaType.parse(contentTypeValue).change(mimeType: 'text/plain');
   return addHeader(headers, 'content-type', contentType.toString());
 }
 

--- a/lib/src/response.dart
+++ b/lib/src/response.dart
@@ -60,7 +60,7 @@ class Response extends Message {
   /// in [headers] will be set appropriately. If there is no existing
   /// Content-Type header, it will be set to "application/octet-stream".
   Response.ok(body,
-      {Map<String, /* String | List<String> */ dynamic> headers,
+      {Map<String, /* String | List<String> */ Object> headers,
       Encoding encoding,
       Map<String, Object> context})
       : this(200,
@@ -88,7 +88,7 @@ class Response extends Message {
   /// Content-Type header, it will be set to "application/octet-stream".
   Response.movedPermanently(location,
       {body,
-      Map<String, /* String | List<String> */ dynamic> headers,
+      Map<String, /* String | List<String> */ Object> headers,
       Encoding encoding,
       Map<String, Object> context})
       : this._redirect(301, location, body, headers, encoding,
@@ -116,7 +116,7 @@ class Response extends Message {
   /// Content-Type header, it will be set to "application/octet-stream".
   Response.found(location,
       {body,
-      Map<String, /* String | List<String> */ dynamic> headers,
+      Map<String, /* String | List<String> */ Object> headers,
       Encoding encoding,
       Map<String, Object> context})
       : this._redirect(302, location, body, headers, encoding,
@@ -145,7 +145,7 @@ class Response extends Message {
   /// Content-Type header, it will be set to "application/octet-stream".
   Response.seeOther(location,
       {body,
-      Map<String, /* String | List<String> */ dynamic> headers,
+      Map<String, /* String | List<String> */ Object> headers,
       Encoding encoding,
       Map<String, Object> context})
       : this._redirect(303, location, body, headers, encoding,
@@ -156,7 +156,7 @@ class Response extends Message {
       int statusCode,
       location,
       body,
-      Map<String, /* String | List<String> */ dynamic> headers,
+      Map<String, /* String | List<String> */ Object> headers,
       Encoding encoding,
       {Map<String, Object> context})
       : this(statusCode,
@@ -173,7 +173,7 @@ class Response extends Message {
   /// since the last request. It indicates that the resource has not changed and
   /// the old value should be used.
   Response.notModified(
-      {Map<String, /* String | List<String> */ dynamic> headers,
+      {Map<String, /* String | List<String> */ Object> headers,
       Map<String, Object> context})
       : this(304,
             headers: addHeader(headers, 'date', formatHttpDate(DateTime.now())),
@@ -198,7 +198,7 @@ class Response extends Message {
   /// in [headers] will be set appropriately. If there is no existing
   /// Content-Type header, it will be set to "application/octet-stream".
   Response.forbidden(body,
-      {Map<String, /* String | List<String> */ dynamic> headers,
+      {Map<String, /* String | List<String> */ Object> headers,
       Encoding encoding,
       Map<String, Object> context})
       : this(403,
@@ -227,7 +227,7 @@ class Response extends Message {
   /// in [headers] will be set appropriately. If there is no existing
   /// Content-Type header, it will be set to "application/octet-stream".
   Response.notFound(body,
-      {Map<String, /* String | List<String> */ dynamic> headers,
+      {Map<String, /* String | List<String> */ Object> headers,
       Encoding encoding,
       Map<String, Object> context})
       : this(404,
@@ -257,7 +257,7 @@ class Response extends Message {
   /// Content-Type header, it will be set to "application/octet-stream".
   Response.internalServerError(
       {body,
-      Map<String, /* String | List<String> */ dynamic> headers,
+      Map<String, /* String | List<String> */ Object> headers,
       Encoding encoding,
       Map<String, Object> context})
       : this(500,
@@ -286,7 +286,7 @@ class Response extends Message {
   /// Content-Type header, it will be set to "application/octet-stream".
   Response(this.statusCode,
       {body,
-      Map<String, /* String | List<String> */ dynamic> headers,
+      Map<String, /* String | List<String> */ Object> headers,
       Encoding encoding,
       Map<String, Object> context})
       : super(body, encoding: encoding, headers: headers, context: context) {
@@ -312,7 +312,7 @@ class Response extends Message {
   /// [Stream<List<int>>], or `<int>[]` (empty list) to indicate no body.
   @override
   Response change(
-      {Map<String, /* String | List<String> */ dynamic> headers,
+      {Map<String, /* String | List<String> */ Object> headers,
       Map<String, Object> context,
       body}) {
     final headersAll = updateMap(this.headersAll, expandToHeadersAll(headers));
@@ -330,7 +330,7 @@ class Response extends Message {
 /// Returns a new map without modifying [headers]. This is used to add
 /// content-type information when creating a 500 response with a default body.
 Map<String, dynamic> _adjustErrorHeaders(
-    Map<String, /* String | List<String> */ dynamic> headers) {
+    Map<String, /* String | List<String> */ Object> headers) {
   if (headers == null || headers['content-type'] == null) {
     return addHeader(headers, 'content-type', 'text/plain');
   }

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -78,6 +78,8 @@ List<String> expandHeaderValue(dynamic v) {
     return [v];
   } else if (v is List<String>) {
     return v;
+  } else if (v == null) {
+    return null;
   } else {
     throw ArgumentError('Expected String or List<String>, got: `$v`.');
   }

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -78,8 +78,6 @@ List<String> expandHeaderValue(dynamic v) {
     return [v];
   } else if (v is List<String>) {
     return v;
-  } else if (v == null) {
-    return null;
   } else {
     throw ArgumentError('Expected String or List<String>, got: `$v`.');
   }

--- a/test/message_change_test.dart
+++ b/test/message_change_test.dart
@@ -62,6 +62,7 @@ void _testChange(
     var copy = request.change(headers: {});
 
     expect(copy.headers, same(request.headers));
+    expect(copy.headersAll, same(request.headersAll));
   });
 
   test('with empty context returns identical instance', () {

--- a/test/message_test.dart
+++ b/test/message_test.dart
@@ -11,8 +11,8 @@ import 'package:test/test.dart';
 import 'test_util.dart';
 
 class _TestMessage extends Message {
-  _TestMessage(Map<String, String> headers, Map<String, Object> context, body,
-      Encoding encoding)
+  _TestMessage(Map<String, /* String | List<String> */ dynamic> headers,
+      Map<String, Object> context, body, Encoding encoding)
       : super(body, headers: headers, context: context, encoding: encoding);
 
   @override
@@ -23,7 +23,7 @@ class _TestMessage extends Message {
 }
 
 Message _createMessage(
-    {Map<String, String> headers,
+    {Map<String, /* String | List<String> */ dynamic> headers,
     Map<String, Object> context,
     body,
     Encoding encoding}) {
@@ -38,6 +38,9 @@ void main() {
       expect(message.headers, containsPair('foo', 'bar'));
       expect(message.headers, containsPair('Foo', 'bar'));
       expect(message.headers, containsPair('FOO', 'bar'));
+      expect(message.headersAll, containsPair('foo', ['bar']));
+      expect(message.headersAll, containsPair('Foo', ['bar']));
+      expect(message.headersAll, containsPair('FOO', ['bar']));
     });
 
     test('null header value becomes default', () {
@@ -46,6 +49,8 @@ void main() {
       expect(message.headers, containsPair('CoNtEnT-lEnGtH', '0'));
       expect(message.headers, same(_createMessage().headers));
       expect(() => message.headers['h1'] = 'value1', throwsUnsupportedError);
+      expect(
+          () => message.headersAll['h1'] = ['value1'], throwsUnsupportedError);
     });
 
     test('headers are immutable', () {
@@ -53,6 +58,29 @@ void main() {
       expect(() => message.headers['h1'] = 'value1', throwsUnsupportedError);
       expect(() => message.headers['h1'] = 'value2', throwsUnsupportedError);
       expect(() => message.headers['h2'] = 'value2', throwsUnsupportedError);
+      expect(
+          () => message.headersAll['h1'] = ['value1'], throwsUnsupportedError);
+      expect(
+          () => message.headersAll['h1'] = ['value2'], throwsUnsupportedError);
+      expect(
+          () => message.headersAll['h2'] = ['value2'], throwsUnsupportedError);
+    });
+
+    test('headers with multiple values', () {
+      final message = _createMessage(headers: {
+        'a': 'A',
+        'b': ['B1', 'B2'],
+      });
+      expect(message.headers, {
+        'a': 'A',
+        'b': 'B1,B2',
+        'content-length': '0',
+      });
+      expect(message.headersAll, {
+        'a': ['A'],
+        'b': ['B1', 'B2'],
+        'content-length': ['0'],
+      });
     });
   });
 

--- a/test/request_test.dart
+++ b/test/request_test.dart
@@ -216,6 +216,7 @@ void main() {
       expect(copy.requestedUri, request.requestedUri);
       expect(copy.protocolVersion, request.protocolVersion);
       expect(copy.headers, same(request.headers));
+      expect(copy.headersAll, same(request.headersAll));
       expect(copy.url, request.url);
       expect(copy.handlerPath, request.handlerPath);
       expect(copy.context, same(request.context));
@@ -226,6 +227,94 @@ void main() {
         controller
           ..add(worldBytes)
           ..close();
+      });
+    });
+
+    group('change headers', () {
+      final request = Request(
+          'GET', Uri.parse('http://localhost:8080/static/file.html'),
+          protocolVersion: '2.0',
+          headers: {'header1': 'header value 1'},
+          url: Uri.parse('file.html'),
+          handlerPath: '/static/',
+          body: '',
+          context: {'context1': 'context value 1'});
+
+      test('delete value with null', () {
+        final r = request.change(headers: {'header1': null});
+        expect(r.headers, {'content-length': '0'});
+        expect(r.headersAll, {
+          'content-length': ['0'],
+        });
+      });
+
+      test('delete value with empty list', () {
+        final r = request.change(headers: {'header1': <String>[]});
+        expect(r.headers, {'content-length': '0'});
+        expect(r.headersAll, {
+          'content-length': ['0'],
+        });
+      });
+
+      test('override value with new String', () {
+        final r = request.change(headers: {'header1': 'new header value'});
+        expect(r.headers, {
+          'header1': 'new header value',
+          'content-length': '0',
+        });
+        expect(r.headersAll, {
+          'header1': ['new header value'],
+          'content-length': ['0'],
+        });
+      });
+
+      test('override value with new single-item List', () {
+        final r = request.change(headers: {
+          'header1': ['new header value']
+        });
+        expect(r.headers, {
+          'header1': 'new header value',
+          'content-length': '0',
+        });
+        expect(r.headersAll, {
+          'header1': ['new header value'],
+          'content-length': ['0'],
+        });
+      });
+
+      test('override value with new multi-item List', () {
+        final r = request.change(headers: {
+          'header1': ['new header value', 'other value']
+        });
+        expect(r.headers, {
+          'header1': 'new header value,other value',
+          'content-length': '0',
+        });
+        expect(r.headersAll, {
+          'header1': ['new header value', 'other value'],
+          'content-length': ['0'],
+        });
+      });
+
+      test('adding a new values', () {
+        final r = request.change(headers: {
+          'a': 'A',
+          'b': ['B1', 'B2'],
+        }).change(headers: {'c': 'C'});
+        expect(r.headers, {
+          'header1': 'header value 1',
+          'content-length': '0',
+          'a': 'A',
+          'b': 'B1,B2',
+          'c': 'C'
+        });
+        expect(r.headersAll, {
+          'header1': ['header value 1'],
+          'content-length': ['0'],
+          'a': ['A'],
+          'b': ['B1', 'B2'],
+          'c': ['C'],
+        });
       });
     });
 

--- a/test/request_test.dart
+++ b/test/request_test.dart
@@ -240,14 +240,6 @@ void main() {
           body: '',
           context: {'context1': 'context value 1'});
 
-      test('delete value with null', () {
-        final r = request.change(headers: {'header1': null});
-        expect(r.headers, {'content-length': '0'});
-        expect(r.headersAll, {
-          'content-length': ['0'],
-        });
-      });
-
       test('delete value with empty list', () {
         final r = request.change(headers: {'header1': <String>[]});
         expect(r.headers, {'content-length': '0'});

--- a/test/request_test.dart
+++ b/test/request_test.dart
@@ -240,6 +240,14 @@ void main() {
           body: '',
           context: {'context1': 'context value 1'});
 
+      test('delete value with null', () {
+        final r = request.change(headers: {'header1': null});
+        expect(r.headers, {'content-length': '0'});
+        expect(r.headersAll, {
+          'content-length': ['0'],
+        });
+      });
+
       test('delete value with empty list', () {
         final r = request.change(headers: {'header1': <String>[]});
         expect(r.headers, {'content-length': '0'});

--- a/test/response_test.dart
+++ b/test/response_test.dart
@@ -136,5 +136,90 @@ void main() {
       expect(changed1.read, throwsStateError);
       expect(response.read, throwsStateError);
     });
+
+    group('change headers', () {
+      final response = Response(
+        345,
+        body: null,
+        headers: {'header1': 'header value 1'},
+      );
+
+      test('delete value with null', () {
+        final r = response.change(headers: {'header1': null});
+        expect(r.headers, {'content-length': '0'});
+        expect(r.headersAll, {
+          'content-length': ['0'],
+        });
+      });
+
+      test('delete value with empty list', () {
+        final r = response.change(headers: {'header1': <String>[]});
+        expect(r.headers, {'content-length': '0'});
+        expect(r.headersAll, {
+          'content-length': ['0'],
+        });
+      });
+
+      test('override value with new String', () {
+        final r = response.change(headers: {'header1': 'new header value'});
+        expect(r.headers, {
+          'header1': 'new header value',
+          'content-length': '0',
+        });
+        expect(r.headersAll, {
+          'header1': ['new header value'],
+          'content-length': ['0'],
+        });
+      });
+
+      test('override value with new single-item List', () {
+        final r = response.change(headers: {
+          'header1': ['new header value']
+        });
+        expect(r.headers, {
+          'header1': 'new header value',
+          'content-length': '0',
+        });
+        expect(r.headersAll, {
+          'header1': ['new header value'],
+          'content-length': ['0'],
+        });
+      });
+
+      test('override value with new multi-item List', () {
+        final r = response.change(headers: {
+          'header1': ['new header value', 'other value']
+        });
+        expect(r.headers, {
+          'header1': 'new header value,other value',
+          'content-length': '0',
+        });
+        expect(r.headersAll, {
+          'header1': ['new header value', 'other value'],
+          'content-length': ['0'],
+        });
+      });
+
+      test('adding a new values', () {
+        final r = response.change(headers: {
+          'a': 'A',
+          'b': ['B1', 'B2'],
+        }).change(headers: {'c': 'C'});
+        expect(r.headers, {
+          'header1': 'header value 1',
+          'content-length': '0',
+          'a': 'A',
+          'b': 'B1,B2',
+          'c': 'C'
+        });
+        expect(r.headersAll, {
+          'header1': ['header value 1'],
+          'content-length': ['0'],
+          'a': ['A'],
+          'b': ['B1', 'B2'],
+          'c': ['C'],
+        });
+      });
+    });
   });
 }

--- a/test/response_test.dart
+++ b/test/response_test.dart
@@ -144,6 +144,14 @@ void main() {
         headers: {'header1': 'header value 1'},
       );
 
+      test('delete value with null', () {
+        final r = response.change(headers: {'header1': null});
+        expect(r.headers, {'content-length': '0'});
+        expect(r.headersAll, {
+          'content-length': ['0'],
+        });
+      });
+
       test('delete value with empty list', () {
         final r = response.change(headers: {'header1': <String>[]});
         expect(r.headers, {'content-length': '0'});

--- a/test/response_test.dart
+++ b/test/response_test.dart
@@ -144,14 +144,6 @@ void main() {
         headers: {'header1': 'header value 1'},
       );
 
-      test('delete value with null', () {
-        final r = response.change(headers: {'header1': null});
-        expect(r.headers, {'content-length': '0'});
-        expect(r.headersAll, {
-          'content-length': ['0'],
-        });
-      });
-
       test('delete value with empty list', () {
         final r = response.change(headers: {'header1': <String>[]});
         expect(r.headers, {'content-length': '0'});

--- a/test/shelf_io_test.dart
+++ b/test/shelf_io_test.dart
@@ -137,6 +137,22 @@ void main() {
     expect(response.body, 'Hello from /');
   });
 
+  test('multiple headers are received from the client', () async {
+    await _scheduleServer((request) {
+      return Response.ok('Hello from /', headers: {
+        'requested-values': request.headersAll['request-values'],
+        'requested-values-length':
+            request.headersAll['request-values'].length.toString(),
+      });
+    });
+
+    // TODO: update test once `package:http` is able to send multiple header values
+    final response = await _get(headers: {'request-values': 'a, b'});
+    expect(response.statusCode, HttpStatus.ok);
+    expect(response.headers['requested-values'], 'a, b');
+    expect(response.headers['requested-values-length'], '1');
+  });
+
   test('custom status code is received by the client', () async {
     await _scheduleServer((request) {
       return Response(299, body: 'Hello from /');

--- a/test/shelf_io_test.dart
+++ b/test/shelf_io_test.dart
@@ -13,6 +13,7 @@ import 'package:http/http.dart' as http;
 import 'package:http_parser/http_parser.dart' as parser;
 import 'package:shelf/shelf.dart';
 import 'package:shelf/shelf_io.dart' as shelf_io;
+import 'package:shelf/src/util.dart';
 import 'package:test/test.dart';
 
 import 'ssl_certs.dart';
@@ -143,14 +144,21 @@ void main() {
         'requested-values': request.headersAll['request-values'],
         'requested-values-length':
             request.headersAll['request-values'].length.toString(),
+        'set-cookie-values': request.headersAll['set-cookie'],
+        'set-cookie-values-length':
+            request.headersAll['set-cookie'].length.toString(),
       });
     });
 
-    // TODO: update test once `package:http` is able to send multiple header values
-    final response = await _get(headers: {'request-values': 'a, b'});
+    final response = await _get(headers: {
+      'request-values': ['a', 'b'],
+      'set-cookie': ['c', 'd'],
+    });
     expect(response.statusCode, HttpStatus.ok);
     expect(response.headers['requested-values'], 'a, b');
     expect(response.headers['requested-values-length'], '1');
+    expect(response.headers['set-cookie-values'], 'c, d');
+    expect(response.headers['set-cookie-values-length'], '2');
   });
 
   test('custom status code is received by the client', () async {
@@ -553,8 +561,30 @@ Future _scheduleServer(Handler handler,
       securityContext: securityContext);
 }
 
-Future<http.Response> _get({Map<String, String> headers}) =>
-    http.get('http://localhost:$_serverPort/', headers: headers ?? {});
+Future<http.Response> _get({
+  Map<String, /* String | List<String> */ Object> headers,
+}) async {
+  // TODO: use http.Client once it supports sending and receiving multiple headers.
+  final client = HttpClient();
+  try {
+    final rq = await client.getUrl(Uri.parse('http://localhost:$_serverPort/'));
+    headers?.forEach((key, value) {
+      rq.headers.add(key, value);
+    });
+    final rs = await rq.close();
+    final rsHeaders = <String, String>{};
+    rs.headers.forEach((name, values) {
+      rsHeaders[name] = joinHeaderValues(values);
+    });
+    return http.Response.fromStream(http.StreamedResponse(
+      rs,
+      rs.statusCode,
+      headers: rsHeaders,
+    ));
+  } finally {
+    client.close(force: true);
+  }
+}
 
 Future<http.StreamedResponse> _post(
     {Map<String, String> headers, String body}) {


### PR DESCRIPTION
- Fixes #44.
- Manually tested that `set-cookie` header is working (`package:http` does not support multiple values).
- The `headers` map is created lazily by calling `.join(',')` on the values. (Consistent in both request and response object, preserves current behaviour when multiple header values are received.)

