### PR TITLE
Improve some style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 ## 0.7.6-dev
 
-* Supports multiple header values in `Request` and `Response`:
-  * `headersAll` field contains all the header values 
-  * `headers` field contains the same values as previously (appending values with `,`)
-  * `headers` parameter in the constructor and in the `.change()` method accepts
-    both `String` and `List<String>` values.
+*   Supports multiple header values in `Request` and `Response`:
+    *   `headersAll` field contains all the header values
+    *   `headers` field contains the same values as previously (appending values
+        with `,`)
+    *   `headers` parameter in the constructor and in the `.change()` method
+        accepts both `String` and `List<String>` values.
 
 ## 0.7.5
 

--- a/lib/src/headers.dart
+++ b/lib/src/headers.dart
@@ -11,7 +11,7 @@ final _emptyHeaders = Headers._empty();
 
 /// Unmodifiable, key-insensitive header map.
 class Headers extends UnmodifiableMapView<String, List<String>> {
-  Map<String, String> _singeValues;
+  Map<String, String> _singleValues;
 
   factory Headers.from(Map<String, List<String>> values) {
     if (values == null || values.isEmpty) {
@@ -24,34 +24,15 @@ class Headers extends UnmodifiableMapView<String, List<String>> {
   }
 
   Headers._(Map<String, List<String>> values)
-      : super(
-          CaseInsensitiveMap<List<String>>.from(
-            Map<String, List<String>>.fromEntries(
-              values.entries
-                  .where((e) => e.value != null && e.value.isNotEmpty)
-                  .map(
-                    (e) => MapEntry<String, List<String>>(
-                      e.key,
-                      List.unmodifiable(e.value),
-                    ),
-                  ),
-            ),
-          ),
-        );
+      : super(CaseInsensitiveMap.from(Map.fromEntries(values.entries
+            .where((e) => e.value?.isNotEmpty ?? false)
+            .map((e) => MapEntry(e.key, List.unmodifiable(e.value))))));
 
-  Headers._empty() : super(<String, List<String>>{});
+  Headers._empty() : super(const {});
   factory Headers.empty() => _emptyHeaders;
 
-  Map<String, String> get singleValues {
-    return _singeValues ??= _SingleValueHeaders(
-      CaseInsensitiveMap<String>.from(
-        map((key, value) =>
-            MapEntry<String, String>(key, joinHeaderValues(value))),
-      ),
-    );
-  }
-}
-
-class _SingleValueHeaders extends UnmodifiableMapView<String, String> {
-  _SingleValueHeaders(Map<String, String> map) : super(map);
+  Map<String, String> get singleValues => _singleValues ??= UnmodifiableMapView(
+        CaseInsensitiveMap.from(
+            map((key, value) => MapEntry(key, joinHeaderValues(value)))),
+      );
 }

--- a/lib/src/message.dart
+++ b/lib/src/message.dart
@@ -25,8 +25,7 @@ final _defaultHeaders = Headers.from({
 abstract class Message {
   final Headers _headers;
 
-  /// The HTTP headers.
-  /// The keys in this Map are normalized, and access is case-insensitive.
+  /// The HTTP headers with case-insensitive keys.
   ///
   /// If a header occurs more than once in the query string, they are mapped to
   /// by concatenating them with a comma.
@@ -34,8 +33,7 @@ abstract class Message {
   /// The returned map is unmodifiable.
   Map<String, String> get headers => _headers.singleValues;
 
-  /// The HTTP headers with multiple values.
-  /// The keys in this Map are normalized, and access is case-insensitive.
+  /// The HTTP headers with multiple values with case-insensitive keys.
   ///
   /// If a header occurs only once, its value is a singleton list.
   /// If a header occurs with no value, the empty string is used as the value


### PR DESCRIPTION
- Rename a private variable with a typo.
- Remove a class that was unnecessarily extending a concrete class
  without overrides.
- Remove some trailing commas that expanded calls onto many more lines
  than necessary.
- Remove explicit generic arguments that can be inferred.
- Add blank lines following the first sentence of some doc comments.