### PR TITLE
Fix #142 by comparing pathSegments as / joined strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.7-dev
+
+* Fix internal error in `Request` when `.change()` matches the full path.
+
 ## 0.7.6
 
 *   Supports multiple header values in `Request` and `Response`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.7.7-dev
+## 0.7.7
 
 * Fix internal error in `Request` when `.change()` matches the full path.
 

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -183,21 +183,9 @@ class Request extends Message {
     // cannot actually combine this.handlerPath and this.url.path, but we can
     // compare the pathSegments. In practice exposing this.url.path as a Uri
     // and not a String is probably the underlying flaw here.
-    final handlerPathSegments = Uri(path: this.handlerPath).pathSegments;
-    // If there is a last pathSegment and it is empty we remove it because it
-    // is only present to retain a trailing slash.
-    Iterable<String> pathSegments = handlerPathSegments;
-    if (handlerPathSegments.isNotEmpty && handlerPathSegments.last.isEmpty) {
-      pathSegments = handlerPathSegments.getRange(
-        0,
-        handlerPathSegments.length - 1,
-      );
-    }
-    pathSegments = pathSegments.followedBy(this.url.pathSegments);
-    if (!IterableEquality().equals(
-      pathSegments,
-      this.requestedUri.pathSegments,
-    )) {
+    final pathSegments = Uri(path: this.handlerPath).pathSegments.join('/') +
+        this.url.pathSegments.join('/');
+    if (pathSegments != this.requestedUri.pathSegments.join('/')) {
       throw ArgumentError.value(
           requestedUri,
           'requestedUri',

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -4,7 +4,6 @@
 
 import 'dart:convert';
 
-import 'package:collection/collection.dart';
 import 'package:http_parser/http_parser.dart';
 import 'package:stream_channel/stream_channel.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf
-version: 0.7.7-dev
+version: 0.7.7
 description: >-
   A model for web server middleware that encourages composition and easy reuse
 homepage: https://github.com/dart-lang/shelf

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf
-version: 0.7.6
+version: 0.7.7-dev
 description: >-
   A model for web server middleware that encourages composition and easy reuse
 homepage: https://github.com/dart-lang/shelf

--- a/test/request_test.dart
+++ b/test/request_test.dart
@@ -355,6 +355,16 @@ void main() {
         expect(copy.url, Uri.parse('file.html'));
       });
 
+      test('regression test for Issue #142', () {
+        var uri = Uri.parse('https://test.example.com/static/dir/');
+        var request = Request('GET', uri,
+            handlerPath: '/static/', url: Uri.parse('dir/'));
+
+        var copy = request.change(path: 'dir');
+        expect(copy.handlerPath, '/static/dir/');
+        expect(copy.url, Uri.parse(''));
+      });
+
       test('throws if path does not match existing uri', () {
         var uri = Uri.parse('https://test.example.com/static/dir/file.html');
         var request = Request('GET', uri,


### PR DESCRIPTION
As proposed in https://github.com/dart-lang/shelf/pull/130/commits/b7da1fd85a159aaea5943d9cadac3efccc8535d7 which we changed to use `IterableEquality().equals` before we landed #130 -- we probably failed to consider all the corner cases.

We could probably also use `IterableEquality().equals` if we add a few more special cases, I haven't exactly worked out what would be needed to make that work.