### PR TITLE
Handle malformed URLs (400 instead of 500).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.8
+
+* Handle malformed URLs (400 instead of 500).
+
 ## 0.7.7
 
 * Fix internal error in `Request` when `.change()` matches the full path.

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -149,7 +149,7 @@ class Request extends Message {
   /// Any [Request] created by calling [change] will pass [_onHijack] from the
   /// source [Request] to ensure that [hijack] can only be called once, even
   /// from a changed [Request].
-  Request._(this.method, Uri requestedUri,
+  Request._(this.method, this.requestedUri,
       {String protocolVersion,
       Map<String, /* String | List<String> */ Object> headers,
       String handlerPath,
@@ -158,8 +158,7 @@ class Request extends Message {
       Encoding encoding,
       Map<String, Object> context,
       _OnHijack onHijack})
-      : requestedUri = requestedUri,
-        protocolVersion = protocolVersion ?? '1.1',
+      : protocolVersion = protocolVersion ?? '1.1',
         url = _computeUrl(requestedUri, handlerPath, url),
         handlerPath = _computeHandlerPath(requestedUri, handlerPath, url),
         _onHijack = onHijack,
@@ -194,7 +193,7 @@ class Request extends Message {
     // and not a String is probably the underlying flaw here.
     final pathSegments = Uri(path: this.handlerPath).pathSegments.join('/') +
         this.url.pathSegments.join('/');
-    if (pathSegments != this.requestedUri.pathSegments.join('/')) {
+    if (pathSegments != requestedUri.pathSegments.join('/')) {
       throw ArgumentError.value(
           requestedUri,
           'requestedUri',

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -168,6 +168,16 @@ class Request extends Message {
       throw ArgumentError.value(method, 'method', 'cannot be empty.');
     }
 
+    try {
+      // Trigger URI parsing methods that may throw format exception (in Request
+      // constructor or in handlers / routing).
+      requestedUri.pathSegments;
+      requestedUri.queryParametersAll;
+    } on FormatException catch (e) {
+      throw ArgumentError.value(
+          requestedUri, 'requestedUri', 'URI parsing failed: $e');
+    }
+
     if (!requestedUri.isAbsolute) {
       throw ArgumentError.value(
           requestedUri, 'requestedUri', 'must be an absolute URL.');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf
-version: 0.7.7
+version: 0.7.8
 description: >-
   A model for web server middleware that encourages composition and easy reuse
 homepage: https://github.com/dart-lang/shelf

--- a/test/io_server_test.dart
+++ b/test/io_server_test.dart
@@ -31,6 +31,14 @@ void main() {
     expect(await http.read(server.url), equals('Hello from /'));
   });
 
+  test('Handles malformed requests gracefully.', () async {
+    server.mount(syncHandler);
+    final rs =
+        await http.get('${server.url}/%D0%C2%BD%A8%CE%C4%BC%FE%BC%D0.zip');
+    expect(rs.statusCode, 400);
+    expect(rs.body, 'Bad Request');
+  });
+
   test('delays HTTP requests until a handler is mounted', () async {
     expect(http.read(server.url), completion(equals('Hello from /')));
     await Future.delayed(Duration.zero);


### PR DESCRIPTION
pub.dev receives a few malformed URLs and we need to return 400 instead of 500 in such cases. Unfortunately `Uri` throws `FormatException` lazily (e.g. accessing path segments).
