### PR TITLE
Adapt outdated code in readme and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,15 +121,16 @@ to capture only errors that would otherwise be top-leveled:
 /// If [this] is called in a non-root error zone, it will just run [callback]
 /// and return the result. Otherwise, it will capture any errors using
 /// [runZoned] and pass them to [onError].
-void catchTopLevelErrors(void Function() callback,
-    void Function(Object error, StackTrace stackTrace) onError) {
+void catchTopLevelErrors(
+  void Function() callback,
+  void Function(Object error, StackTrace stackTrace) onError,
+) {
   if (Zone.current.inSameErrorZone(Zone.root)) {
     return runZonedGuarded(callback, onError);
   } else {
     return callback();
   }
 }
-
 ```
 
 An adapter that knows its own URL should provide an implementation of the

--- a/README.md
+++ b/README.md
@@ -22,13 +22,12 @@ See `example/example.dart`
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:shelf/shelf_io.dart' as io;
 
-void main() {
+Future<void> main() async {
   var handler = const shelf.Pipeline().addMiddleware(shelf.logRequests())
       .addHandler(_echoRequest);
 
-  io.serve(handler, 'localhost', 8080).then((server) {
-    print('Serving at http://${server.address.host}:${server.port}');
-  });
+  var server = await io.serve(handler, 'localhost', 8080);
+  print('Serving at http://${server.address.host}:${server.port}');
 }
 
 shelf.Response _echoRequest(shelf.Request request) {
@@ -122,13 +121,15 @@ to capture only errors that would otherwise be top-leveled:
 /// If [this] is called in a non-root error zone, it will just run [callback]
 /// and return the result. Otherwise, it will capture any errors using
 /// [runZoned] and pass them to [onError].
-catchTopLevelErrors(callback(), void onError(error, StackTrace stackTrace)) {
-  if (Zone.current.inSameErrorZone(Zone.ROOT)) {
-    return runZoned(callback, onError: onError);
+void catchTopLevelErrors(void Function() callback,
+    void Function(Object error, StackTrace stackTrace) onError) {
+  if (Zone.current.inSameErrorZone(Zone.root)) {
+    return runZonedGuarded(callback, onError);
   } else {
     return callback();
   }
 }
+
 ```
 
 An adapter that knows its own URL should provide an implementation of the

--- a/test/create_middleware_test.dart
+++ b/test/create_middleware_test.dart
@@ -9,11 +9,6 @@ import 'package:test/test.dart';
 
 import 'test_util.dart';
 
-// TODO(kevmoo): remove this helper https://github.com/dart-lang/test/issues/740
-T _fail<T>(String message) {
-  fail(message);
-}
-
 void main() {
   test('forwards the request and response if both handlers are null', () {
     var handler = const Pipeline()
@@ -75,7 +70,7 @@ void main() {
       test('with sync result, responseHandler is not called', () {
         var middleware = createMiddleware(
             requestHandler: (request) => _middlewareResponse,
-            responseHandler: (response) => _fail('should not be called'));
+            responseHandler: (response) => fail('should not be called'));
 
         var handler =
             const Pipeline().addMiddleware(middleware).addHandler(syncHandler);
@@ -88,7 +83,7 @@ void main() {
       test('with async result, responseHandler is not called', () {
         var middleware = createMiddleware(
             requestHandler: (request) => Future.value(_middlewareResponse),
-            responseHandler: (response) => _fail('should not be called'));
+            responseHandler: (response) => fail('should not be called'));
         var handler =
             const Pipeline().addMiddleware(middleware).addHandler(syncHandler);
 
@@ -153,7 +148,7 @@ void main() {
           responseHandler: (response) {
             throw 'middleware error';
           },
-          errorHandler: (e, s) => _fail('should never get here'));
+          errorHandler: (e, s) => fail('should never get here'));
 
       var handler =
           const Pipeline().addMiddleware(middleware).addHandler(syncHandler);
@@ -166,7 +161,7 @@ void main() {
           requestHandler: (request) {
             throw 'middleware error';
           },
-          errorHandler: (e, s) => _fail('should never get here'));
+          errorHandler: (e, s) => fail('should never get here'));
 
       var handler =
           const Pipeline().addMiddleware(middleware).addHandler(syncHandler);
@@ -231,7 +226,7 @@ void main() {
   });
 }
 
-Response _failHandler(Request request) => _fail('should never get here');
+Response _failHandler(Request request) => fail('should never get here');
 
 final Response _middlewareResponse =
     Response.ok('middleware content', headers: {'from': 'middleware'});


### PR DESCRIPTION
I adapted the example to use async/await and the "new" syntax for function types. I also changed the error handling example to use non-deprecated `Zone` apis. Finally, I resolved one ancient todo in `create_middleware_test.dart`.

Fixes #150.