### PR TITLE
Restore handling of null response

### DIFF
--- a/lib/shelf_io.dart
+++ b/lib/shelf_io.dart
@@ -130,6 +130,12 @@ Future handleRequest(HttpRequest request, Handler handler) async {
     );
   }
 
+  if ((response as dynamic) == null) {
+    // Handle nulls flowing from opt-out code
+    await _writeResponse(_logError(shelfRequest, 'null response from handler.'),
+        request.response);
+    return;
+  }
   if (shelfRequest.canHijack) {
     await _writeResponse(response, request.response);
     return;

--- a/test/opt_out_io_test.dart
+++ b/test/opt_out_io_test.dart
@@ -29,7 +29,7 @@ void main() {
   });
 
   test('async null response leads to a 500', () async {
-    await _scheduleServer((request) => Future.value(null));
+    await _scheduleServer((request) async => null);
 
     var response = await _get();
     expect(response.statusCode, HttpStatus.internalServerError);

--- a/test/opt_out_io_test.dart
+++ b/test/opt_out_io_test.dart
@@ -1,0 +1,82 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// @dart=2.9
+@TestOn('vm')
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:shelf/shelf.dart';
+import 'package:shelf/shelf_io.dart' as shelf_io;
+import 'package:shelf/src/util.dart';
+import 'package:test/test.dart';
+
+void main() {
+  tearDown(() async {
+    if (_server != null) {
+      await _server.close(force: true);
+      _server = null;
+    }
+  });
+
+  test('sync null response leads to a 500', () async {
+    await _scheduleServer((request) => null);
+
+    var response = await _get();
+    expect(response.statusCode, HttpStatus.internalServerError);
+    expect(response.body, 'Internal Server Error');
+  });
+
+  test('async null response leads to a 500', () async {
+    await _scheduleServer((request) => Future.value(null));
+
+    var response = await _get();
+    expect(response.statusCode, HttpStatus.internalServerError);
+    expect(response.body, 'Internal Server Error');
+  });
+}
+
+int get _serverPort => _server.port;
+
+HttpServer _server;
+
+Future _scheduleServer(
+  Handler handler, {
+  SecurityContext securityContext,
+}) async {
+  assert(_server == null);
+  _server = await shelf_io.serve(
+    handler,
+    'localhost',
+    0,
+    securityContext: securityContext,
+  );
+}
+
+Future<http.Response> _get({
+  Map<String, /* String | List<String> */ Object> headers,
+  String path = '',
+}) async {
+  // TODO: use http.Client once it supports sending and receiving multiple headers.
+  final client = HttpClient();
+  try {
+    final rq =
+        await client.getUrl(Uri.parse('http://localhost:$_serverPort/$path'));
+    headers?.forEach((key, value) {
+      rq.headers.add(key, value);
+    });
+    final rs = await rq.close();
+    final rsHeaders = <String, String>{};
+    rs.headers.forEach((name, values) {
+      rsHeaders[name] = joinHeaderValues(values);
+    });
+    return http.Response.fromStream(http.StreamedResponse(
+      rs,
+      rs.statusCode,
+      headers: rsHeaders,
+    ));
+  } finally {
+    client.close(force: true);
+  }
+}

--- a/test/shelf_io_test.dart
+++ b/test/shelf_io_test.dart
@@ -42,7 +42,6 @@ void main() {
     expect(response.body, 'Hello from /');
   });
 
-
   test('thrown error leads to a 500', () async {
     await _scheduleServer((request) {
       throw UnsupportedError('test');

--- a/test/shelf_io_test.dart
+++ b/test/shelf_io_test.dart
@@ -42,21 +42,6 @@ void main() {
     expect(response.body, 'Hello from /');
   });
 
-  test('sync null response leads to a 500', () async {
-    await _scheduleServer((request) => Response.internalServerError());
-
-    var response = await _get();
-    expect(response.statusCode, HttpStatus.internalServerError);
-    expect(response.body, 'Internal Server Error');
-  });
-
-  test('async null response leads to a 500', () async {
-    await _scheduleServer((request) => Future.value(null));
-
-    var response = await _get();
-    expect(response.statusCode, HttpStatus.internalServerError);
-    expect(response.body, 'Internal Server Error');
-  });
 
   test('thrown error leads to a 500', () async {
     await _scheduleServer((request) {


### PR DESCRIPTION
Opt-in code cannot pass a null response, however opt-out code can.
Retain check for a null `Response`, cast to `dynamic` to silence
analyzer warning.

Add a test that specifically opts out of null safety to test this
behavior.