### PR TITLE
Add shim for old unsound null behavior

### DIFF
--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -97,6 +97,8 @@ class Request extends Message {
   /// If [encoding] is passed, the "encoding" field of the Content-Type header
   /// in [headers] will be set appropriately. If there is no existing
   /// Content-Type header, it will be set to "application/octet-stream".
+  /// [headers] must contain values that are either `String` or `List<String>`.
+  /// An empty list will cause the header to be omitted.
   ///
   /// The default value for [protocolVersion] is '1.1'.
   ///
@@ -217,6 +219,8 @@ class Request extends Message {
   /// [Request]. If [context] or [headers] contains a `null` value the
   /// corresponding `key` will be removed if it exists, otherwise the `null`
   /// value will be ignored.
+  /// For [headers] a value which is an empty list will also cause the
+  /// corresponding key to be removed.
   ///
   /// All other context and header values from the [Request] will be
   /// included in the copied [Request] unchanged.

--- a/lib/src/response.dart
+++ b/lib/src/response.dart
@@ -59,6 +59,8 @@ class Response extends Message {
   /// If [encoding] is passed, the "encoding" field of the Content-Type header
   /// in [headers] will be set appropriately. If there is no existing
   /// Content-Type header, it will be set to "application/octet-stream".
+  /// [headers] must contain values that are either `String` or `List<String>`.
+  /// An empty list will cause the header to be omitted.
   Response.ok(
     body, {
     Map<String, /* String | List<String> */ Object>? headers,
@@ -87,6 +89,8 @@ class Response extends Message {
   /// If [encoding] is passed, the "encoding" field of the Content-Type header
   /// in [headers] will be set appropriately. If there is no existing
   /// Content-Type header, it will be set to "application/octet-stream".
+  /// [headers] must contain values that are either `String` or `List<String>`.
+  /// An empty list will cause the header to be omitted.
   Response.movedPermanently(
     Object location, {
     body,
@@ -115,6 +119,8 @@ class Response extends Message {
   /// If [encoding] is passed, the "encoding" field of the Content-Type header
   /// in [headers] will be set appropriately. If there is no existing
   /// Content-Type header, it will be set to "application/octet-stream".
+  /// [headers] must contain values that are either `String` or `List<String>`.
+  /// An empty list will cause the header to be omitted.
   Response.found(
     Object location, {
     body,
@@ -151,6 +157,8 @@ class Response extends Message {
   /// If [encoding] is passed, the "encoding" field of the Content-Type header
   /// in [headers] will be set appropriately. If there is no existing
   /// Content-Type header, it will be set to "application/octet-stream".
+  /// [headers] must contain values that are either `String` or `List<String>`.
+  /// An empty list will cause the header to be omitted.
   Response.seeOther(
     Object location, {
     body,
@@ -181,6 +189,9 @@ class Response extends Message {
   /// information used to determine whether the requested resource has changed
   /// since the last request. It indicates that the resource has not changed and
   /// the old value should be used.
+  ///
+  /// [headers] must contain values that are either `String` or `List<String>`.
+  /// An empty list will cause the header to be omitted.
   Response.notModified({
     Map<String, /* String | List<String> */ Object>? headers,
     Map<String, Object>? context,
@@ -208,6 +219,8 @@ class Response extends Message {
   /// If [encoding] is passed, the "encoding" field of the Content-Type header
   /// in [headers] will be set appropriately. If there is no existing
   /// Content-Type header, it will be set to "application/octet-stream".
+  /// [headers] must contain values that are either `String` or `List<String>`.
+  /// An empty list will cause the header to be omitted.
   Response.forbidden(
     body, {
     Map<String, /* String | List<String> */ Object>? headers,
@@ -240,6 +253,8 @@ class Response extends Message {
   /// If [encoding] is passed, the "encoding" field of the Content-Type header
   /// in [headers] will be set appropriately. If there is no existing
   /// Content-Type header, it will be set to "application/octet-stream".
+  /// [headers] must contain values that are either `String` or `List<String>`.
+  /// An empty list will cause the header to be omitted.
   Response.notFound(
     body, {
     Map<String, /* String | List<String> */ Object>? headers,
@@ -272,6 +287,8 @@ class Response extends Message {
   /// If [encoding] is passed, the "encoding" field of the Content-Type header
   /// in [headers] will be set appropriately. If there is no existing
   /// Content-Type header, it will be set to "application/octet-stream".
+  /// [headers] must contain values that are either `String` or `List<String>`.
+  /// An empty list will cause the header to be omitted.
   Response.internalServerError({
     body,
     Map<String, /* String | List<String> */ Object>? headers,
@@ -303,6 +320,8 @@ class Response extends Message {
   /// If [encoding] is passed, the "encoding" field of the Content-Type header
   /// in [headers] will be set appropriately. If there is no existing
   /// Content-Type header, it will be set to "application/octet-stream".
+  /// [headers] must contain values that are either `String` or `List<String>`.
+  /// An empty list will cause the header to be omitted.
   Response(
     this.statusCode, {
     body,
@@ -326,6 +345,8 @@ class Response extends Message {
   /// [Response]. If [context] or [headers] contains a `null` value the
   /// corresponding `key` will be removed if it exists, otherwise the `null`
   /// value will be ignored.
+  /// For [headers] a value which is an empty list will also cause the
+  /// corresponding key to be removed.
   ///
   /// All other context and header values from the [Response] will be included
   /// in the copied [Response] unchanged.

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -114,6 +114,8 @@ List<String> expandHeaderValue(Object v) {
     return [v];
   } else if (v is List<String>) {
     return v;
+  } else if ((v as dynamic) == null) {
+    return const [];
   } else {
     throw ArgumentError('Expected String or List<String>, got: `$v`.');
   }

--- a/test/opt_out_test.dart
+++ b/test/opt_out_test.dart
@@ -1,0 +1,15 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// @dart=2.9
+
+import 'package:shelf/shelf.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('allows a null value to elide a header', () {
+    expect(Response.ok('', headers: {'some_header': null}).headers,
+        isNot(contains('some_header')));
+  });
+}


### PR DESCRIPTION
Keep the static type of the Headers map as non-null so that migrated
libraries need to make explicit the behavior for nulls rather than
relying on the hidden detail from `package:shelf`. Cast to `dynamic` to
avoid analysis warnings and check for nulls with a fallback that will
retain the behavior pre-migration of dropping the header.