### PR TITLE
Avoid wrapping List<int>/Stream<List<int>> response bodies in a CastList/CastStream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.1
+
+* Avoid wraping response bodies that already contained `List<int>` in a `CastList`.
+  This will improve the performance of large response bodies
+
 ## 1.1.0
 
 * Change `Request.hijack` return type from `void` to `Never`. This may cause

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## 1.1.1
 
-* Avoid wraping response bodies that already contained `List<int>` in a `CastList`.
-  This will improve the performance of large response bodies
+* Avoid wraping response bodies that already contained `List<int>` or `Stream<List<int>>` in a `CastList`/`CastStream` to improve performance.
 
 ## 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 1.1.1
 
-* Avoid wraping response bodies that already contained `List<int>` or `Stream<List<int>>` in a `CastList`/`CastStream` to improve performance.
+* Avoid wrapping response bodies that already contained `List<int>` or
+  `Stream<List<int>>` in a `CastList`/`CastStream` to improve
+  performance.
 
 ## 1.1.0
 

--- a/lib/src/body.dart
+++ b/lib/src/body.dart
@@ -5,8 +5,6 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'dart:typed_data';
-
 /// The body of a request or response.
 ///
 /// This tracks whether the body has been read. It's separate from [Message]

--- a/lib/src/body.dart
+++ b/lib/src/body.dart
@@ -5,6 +5,8 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'dart:typed_data';
+
 /// The body of a request or response.
 ///
 /// This tracks whether the body has been read. It's separate from [Message]
@@ -52,6 +54,13 @@ class Body {
         contentLength = encoded.length;
         stream = Stream.fromIterable([encoded]);
       }
+    } else if (body is Uint8List) {
+      // Any data that is written to a Dart socket that is not a Uint8List or
+      // Int8List must be copied into a new list. Allow users to provide a
+      // typed data object to avoid this copy, which is important for performance
+      // of large file requests.
+      contentLength = body.length;
+      stream = Stream.fromIterable([body]);
     } else if (body is List) {
       contentLength = body.length;
       stream = Stream.fromIterable([body.cast()]);

--- a/lib/src/body.dart
+++ b/lib/src/body.dart
@@ -53,15 +53,12 @@ class Body {
         stream = Stream.fromIterable([encoded]);
       }
     } else if (body is List<int>) {
-      // Any data that is written to a Dart socket that is not a Uint8List or
-      // Int8List must be copied into a new list. Allow users to provide a
-      // typed data object to avoid this copy, which is important for performance
-      // of large file requests.
+      // Avoid performance overhead from an unnecessary cast.
       contentLength = body.length;
-      stream = Stream.fromIterable([body]);
+      stream = Stream.value(body);
     } else if (body is List) {
       contentLength = body.length;
-      stream = Stream.fromIterable([body.cast()]);
+      stream = Stream.value(body.cast());
     } else if (body is Stream) {
       stream = body.cast();
     } else {

--- a/lib/src/body.dart
+++ b/lib/src/body.dart
@@ -59,6 +59,9 @@ class Body {
     } else if (body is List) {
       contentLength = body.length;
       stream = Stream.value(body.cast());
+    } else if (body is Stream<List<int>>) {
+      // Avoid performance overhead from an unnecessary cast.
+      stream = body;
     } else if (body is Stream) {
       stream = body.cast();
     } else {

--- a/lib/src/body.dart
+++ b/lib/src/body.dart
@@ -54,7 +54,7 @@ class Body {
         contentLength = encoded.length;
         stream = Stream.fromIterable([encoded]);
       }
-    } else if (body is Uint8List) {
+    } else if (body is List<int>) {
       // Any data that is written to a Dart socket that is not a Uint8List or
       // Int8List must be copied into a new list. Allow users to provide a
       // typed data object to avoid this copy, which is important for performance

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf
-version: 1.1.0
+version: 1.1.1
 description: >-
   A model for web server middleware that encourages composition and easy reuse
 repository: https://github.com/dart-lang/shelf

--- a/test/response_test.dart
+++ b/test/response_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:shelf/shelf.dart' hide Request;
 import 'package:test/test.dart';
@@ -23,6 +24,14 @@ void main() {
       var response = Response.ok('hello, world');
       expect(response.read().toList(), completion(equals([helloWorldBytes])));
     });
+  });
+
+  test('supports a Uint8List body without copying', () async {
+    var bytes = Uint8List(10);
+    var response = Response.ok(bytes);
+
+    expect(response.contentLength, 10);
+    expect(identical(await response.read().first, bytes), true);
   });
 
   group('new Response.internalServerError without a body', () {

--- a/test/response_test.dart
+++ b/test/response_test.dart
@@ -31,7 +31,7 @@ void main() {
     var response = Response.ok(bytes);
 
     expect(response.contentLength, 10);
-    expect(identical(await response.read().first, bytes), true);
+    expect(await response.read().single, same(bytes));
   });
 
   test('supports a List<int> body without copying', () async {
@@ -39,7 +39,7 @@ void main() {
     var response = Response.ok(bytes);
 
     expect(response.contentLength, 4);
-    expect(identical(await response.read().first, bytes), true);
+    expect(await response.read().single, same(bytes));
   });
 
   test('Copies a dynamic list of int elements', () async {
@@ -47,7 +47,10 @@ void main() {
     var response = Response.ok(bytes);
 
     expect(response.contentLength, 4);
-    expect(await response.read().first, <int>[1, 2, 3, 4]);
+    expect(
+        await response.read().single,
+        isA<List<int>>()
+            .having((List<int> values) => values, 'values', [1, 2, 3, 4]));
   });
 
   group('new Response.internalServerError without a body', () {

--- a/test/response_test.dart
+++ b/test/response_test.dart
@@ -42,15 +42,20 @@ void main() {
     expect(await response.read().single, same(bytes));
   });
 
+  test('supports a Stream<List<int>> body without copying', () async {
+    var bytes = Stream.value(<int>[1, 2, 3, 4]);
+    var response = Response.ok(bytes);
+
+    expect(response.read(), same(bytes));
+  });
+
   test('Copies a dynamic list of int elements', () async {
     var bytes = <dynamic>[1, 2, 3, 4];
     var response = Response.ok(bytes);
 
     expect(response.contentLength, 4);
-    expect(
-        await response.read().single,
-        isA<List<int>>()
-            .having((List<int> values) => values, 'values', [1, 2, 3, 4]));
+    expect(await response.read().single,
+        isA<List<int>>().having((values) => values, 'values', [1, 2, 3, 4]));
   });
 
   group('new Response.internalServerError without a body', () {

--- a/test/response_test.dart
+++ b/test/response_test.dart
@@ -34,6 +34,22 @@ void main() {
     expect(identical(await response.read().first, bytes), true);
   });
 
+  test('supports a List<int> body without copying', () async {
+    var bytes = <int>[1, 2, 3, 4];
+    var response = Response.ok(bytes);
+
+    expect(response.contentLength, 4);
+    expect(identical(await response.read().first, bytes), true);
+  });
+
+  test('Copies a dynamic list of int elements', () async {
+    var bytes = <dynamic>[1, 2, 3, 4];
+    var response = Response.ok(bytes);
+
+    expect(response.contentLength, 4);
+    expect(await response.read().first, <int>[1, 2, 3, 4]);
+  });
+
   group('new Response.internalServerError without a body', () {
     test('sets the body to "Internal Server Error"', () {
       var response = Response.internalServerError();


### PR DESCRIPTION
(Allows https://github.com/flutter/flutter/issues/81010 to be fixed, though we need to change some code on the flutter side too)

TLDR: when writing data to a socket in dart, anything besides a Uint8List or Int8List will be necessarily copied (c.f. https://github.com/dart-lang/sdk/blob/3f0ad61daaac68e591bf01d0a3096926c30c1d42/sdk/lib/io/common.dart#L92)

shelf will unnecessarily wrap all Lists in a CastList which will perform runtime checks for every single element.

The combination of these behaviors causes requests for large files in the flutter run web server to be incredibly slow, observed to be on the order of multiple minutes locally. With the combination of this change and a patch to the tool to avoid creating Uint8List views, the time to serve the app drops to a few seconds.


I took a CPU profile starting from when chrome opened until the app's first frame. I could upload the actual timeline data too, but a picture something something a thousand words

# Before:

![Dart DevTools - Google Chrome 4_22_2021 5_50_04 PM](https://user-images.githubusercontent.com/8975114/115802293-77c74480-a393-11eb-8cd3-bd628d8b15bb.png)


# After:

![Dart DevTools - Google Chrome 4_22_2021 5_50_52 PM](https://user-images.githubusercontent.com/8975114/115802321-83b30680-a393-11eb-90d5-3420b6dc0355.png)

