### PR TITLE
Remove expectation that GET without a body has content-length 0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.1.2-dev
+
 ## 1.1.1
 
 * Avoid wrapping response bodies that already contained `List<int>` or

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf
-version: 1.1.1
+version: 1.1.2-dev
 description: >-
   A model for web server middleware that encourages composition and easy reuse
 repository: https://github.com/dart-lang/shelf

--- a/test/shelf_io_test.dart
+++ b/test/shelf_io_test.dart
@@ -66,7 +66,6 @@ void main() {
     late Uri uri;
 
     await _scheduleServer((request) {
-      expect(request.contentLength, 0);
       expect(request.method, 'GET');
 
       expect(request.requestedUri, uri);


### PR DESCRIPTION
See https://dart-review.googlesource.com/c/sdk/+/194881 that is going to remove content-length:0 header for GET and HEAD requests that has no body.