### PR TITLE
Allow an explicit non-zero content-length header if the body is empty.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-## 1.1.2-dev
+## 1.1.2
+
+* Allow an explicit non-zero content-length header if the body is empty.
+  (Needed to correctly support HEAD requests).
 
 ## 1.1.1
 

--- a/lib/src/message.dart
+++ b/lib/src/message.dart
@@ -206,7 +206,12 @@ Map<String, List<String>> _adjustHeaders(
     }
   }
 
-  if (body.contentLength != null) {
+  if (body.contentLength != null &&
+      !(
+          // If the contentLength is 0 and there's an explicit content-length
+          // in the headers, user the header value – needed for HEAD requests!
+          body.contentLength == 0 &&
+              findHeader(headers, 'content-length') != null)) {
     final coding = joinHeaderValues(newHeaders['transfer-encoding']);
     if (coding == null || equalsIgnoreAsciiCase(coding, 'identity')) {
       newHeaders['content-length'] = [body.contentLength.toString()];

--- a/lib/src/message.dart
+++ b/lib/src/message.dart
@@ -206,12 +206,10 @@ Map<String, List<String>> _adjustHeaders(
     }
   }
 
-  if (body.contentLength != null &&
-      !(
-          // If the contentLength is 0 and there's an explicit content-length
-          // in the headers, user the header value – needed for HEAD requests!
-          body.contentLength == 0 &&
-              findHeader(headers, 'content-length') != null)) {
+  final explicitOverrideOfZeroLength =
+      body.contentLength == 0 && findHeader(headers, 'content-length') != null;
+
+  if (body.contentLength != null && !explicitOverrideOfZeroLength) {
     final coding = joinHeaderValues(newHeaders['transfer-encoding']);
     if (coding == null || equalsIgnoreAsciiCase(coding, 'identity')) {
       newHeaders['content-length'] = [body.contentLength.toString()];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf
-version: 1.1.2-dev
+version: 1.1.2
 description: >-
   A model for web server middleware that encourages composition and easy reuse
 repository: https://github.com/dart-lang/shelf

--- a/test/response_test.dart
+++ b/test/response_test.dart
@@ -58,6 +58,14 @@ void main() {
         isA<List<int>>().having((values) => values, 'values', [1, 2, 3, 4]));
   });
 
+  test('allows content-length header even if body is null', () async {
+    // needed for HEAD responses
+    var response = Response.ok(null, headers: {'Content-Length': '42'});
+
+    expect(response.contentLength, 42);
+    expect(await response.readAsString(), isEmpty);
+  });
+
   group('new Response.internalServerError without a body', () {
     test('sets the body to "Internal Server Error"', () {
       var response = Response.internalServerError();


### PR DESCRIPTION
Needed to correctly support HEAD requests

Also prepare to release v1.1.2
