### PR TITLE
Add a test for non-zero content-length header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.1.3-dev
+
 ## 1.1.2
 
 * Allow an explicit non-zero content-length header if the body is empty.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf
-version: 1.1.2
+version: 1.1.3-dev
 description: >-
   A model for web server middleware that encourages composition and easy reuse
 repository: https://github.com/dart-lang/shelf


### PR DESCRIPTION
Demonstrate that a non-zero `content-length` header can be sent through
the `dart:io` server for a request with an empty body.