### PR TITLE
Remove content-length for notModified responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## 1.1.3-dev
+## 1.1.3
+
+* Automatically remove `content-length` header from a `Response.notModified`.
+  Restores some of the safety around malformed requests that was removed in
+  `1.1.2` where we started allowing `content-length` for some responses without
+  bodies.
 
 ## 1.1.2
 

--- a/lib/src/response.dart
+++ b/lib/src/response.dart
@@ -192,12 +192,16 @@ class Response extends Message {
   ///
   /// [headers] must contain values that are either `String` or `List<String>`.
   /// An empty list will cause the header to be omitted.
+  ///
+  /// If [headers] contains a value for `content-length` it will be removed.
   Response.notModified({
     Map<String, /* String | List<String> */ Object>? headers,
     Map<String, Object>? context,
   }) : this(
           304,
-          headers: addHeader(headers, 'date', formatHttpDate(DateTime.now())),
+          headers: removeHeader(
+              addHeader(headers, 'date', formatHttpDate(DateTime.now())),
+              'content-length'),
           context: context,
         );
 

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -58,6 +58,18 @@ Map<String, Object> addHeader(
   return headers;
 }
 
+/// Removed the header with case-insensitive name [name].
+///
+/// Returns a new map without modifying [headers].
+Map<String, Object> removeHeader(
+  Map<String, Object>? headers,
+  String name,
+) {
+  headers = headers == null ? {} : Map.from(headers);
+  headers.removeWhere((header, value) => equalsIgnoreAsciiCase(header, name));
+  return headers;
+}
+
 /// Returns the header with the given [name] in [headers].
 ///
 /// This works even if [headers] is `null`, or if it's not yet a

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf
-version: 1.1.3-dev
+version: 1.1.3
 description: >-
   A model for web server middleware that encourages composition and easy reuse
 repository: https://github.com/dart-lang/shelf

--- a/test/response_test.dart
+++ b/test/response_test.dart
@@ -66,6 +66,13 @@ void main() {
     expect(await response.readAsString(), isEmpty);
   });
 
+  test('clears content-length for notModified response', () async {
+    var response = Response.notModified(headers: {'Content-Length': '42'});
+
+    expect(response.contentLength, 0);
+    expect(await response.readAsString(), isEmpty);
+  });
+
   group('new Response.internalServerError without a body', () {
     test('sets the body to "Internal Server Error"', () {
       var response = Response.internalServerError();


### PR DESCRIPTION
It is an error to include a non-zero content-length when there is no
body. In some places, especially those where we are implementing a
proxy, we were previously relying on behavior in shelf which would zero
out the content length when there is no body. After allowing a content
length without a body for `HEAD` requests we lost the safety for other
request types.

The errors that have surfaced since published are related to
`Response.notModified` which should never have a `content-length`, so
handling it there should retain most of the safety we had before. There
is still the possibility for problems in other response types which will
need to be handled at the usage site.