### PR TITLE
Documentation cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.4-dev
+
+* Documentation cleanup.
+
 ## 1.1.3
 
 * Automatically remove `content-length` header from a `Response.notModified`.

--- a/lib/shelf_io.dart
+++ b/lib/shelf_io.dart
@@ -35,7 +35,7 @@ export 'src/io_server.dart';
 /// [port] and sends requests to [handler].
 ///
 /// If a [securityContext] is provided an HTTPS server will be started.
-////
+///
 /// See the documentation for [HttpServer.bind] and [HttpServer.bindSecure]
 /// for more details on [address], [port], [backlog], and [shared].
 Future<HttpServer> serve(

--- a/lib/src/cascade.dart
+++ b/lib/src/cascade.dart
@@ -20,11 +20,13 @@ typedef _ShouldCascade = bool Function(Response response);
 /// If all handlers return unacceptable responses, the final response will be
 /// returned.
 ///
-///     var handler = new Cascade()
-///         .add(webSocketHandler)
-///         .add(staticFileHandler)
-///         .add(application)
-///         .handler;
+/// ```dart
+///  var handler = new Cascade()
+///      .add(webSocketHandler)
+///      .add(staticFileHandler)
+///      .add(application)
+///      .handler;
+/// ```
 class Cascade {
   /// The function used to determine whether the cascade should continue on to
   /// the next handler.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf
-version: 1.1.3
+version: 1.1.4-dev
 description: >-
   A model for web server middleware that encourages composition and easy reuse
 repository: https://github.com/dart-lang/shelf


### PR DESCRIPTION
Remove extra slash in shelf_io doc comment
Use triple-tick dart syntax for example
