### PR TITLE
add explicit show clauses on exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.2.1-dev
+
 ## 1.2.0
 
 * Added `MiddlewareExtensions` which provides `addMiddleware` and `addHandler`

--- a/lib/shelf.dart
+++ b/lib/shelf.dart
@@ -2,15 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-export 'src/cascade.dart';
-export 'src/handler.dart';
-export 'src/hijack_exception.dart';
-export 'src/middleware.dart';
-export 'src/middleware/add_chunked_encoding.dart';
-export 'src/middleware/logger.dart';
-export 'src/middleware_extensions.dart';
-export 'src/pipeline.dart';
-export 'src/request.dart';
-export 'src/response.dart';
-export 'src/server.dart';
-export 'src/server_handler.dart';
+export 'src/cascade.dart' show Cascade;
+export 'src/handler.dart' show Handler;
+export 'src/hijack_exception.dart' show HijackException;
+export 'src/middleware.dart' show Middleware, createMiddleware;
+export 'src/middleware/add_chunked_encoding.dart' show addChunkedEncoding;
+export 'src/middleware/logger.dart' show logRequests;
+export 'src/middleware_extensions.dart' show MiddlewareExtensions;
+export 'src/pipeline.dart' show Pipeline;
+export 'src/request.dart' show Request;
+export 'src/response.dart' show Response;
+export 'src/server.dart' show Server;
+export 'src/server_handler.dart' show ServerHandler;

--- a/lib/shelf_io.dart
+++ b/lib/shelf_io.dart
@@ -29,7 +29,7 @@ import 'package:stream_channel/stream_channel.dart';
 import 'shelf.dart';
 import 'src/util.dart';
 
-export 'src/io_server.dart';
+export 'src/io_server.dart' show IOServer;
 
 /// Starts an [HttpServer] that listens on the specified [address] and
 /// [port] and sends requests to [handler].

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf
-version: 1.2.0
+version: 1.2.1-dev
 description: >-
   A model for web server middleware that encourages composition and easy reuse
 repository: https://github.com/dart-lang/shelf


### PR DESCRIPTION
This package is used as an example of good package layout here https://dart.dev/guides/libraries/create-library-packages#organizing-a-library-package, we should make it explicitly show all the things it exports as a good example :). 