### PR TITLE
Add serveGuarded and serveRequestsGuarded API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.2.1-dev
+## 1.3.0-dev
 
 * Added `serveGuarded` and `serveRequestGuarded` API that always serve
   requests in an error zone, capture async error traces, and use provided

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.2.1-dev
 
+* Added `serveGuarded` and `serveRequestGuarded` API that always serve
+  requests in an error zone, capture async error traces, and use provided
+  error handler to handle errors.
+
 ## 1.2.0
 
 * Added `MiddlewareExtensions` which provides `addMiddleware` and `addHandler`

--- a/lib/shelf_io.dart
+++ b/lib/shelf_io.dart
@@ -2,10 +2,12 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore_for_file: deprecated_member_use_from_same_package
+
 /// A Shelf adapter for handling [HttpRequest] objects from `dart:io`.
 ///
 /// One can provide an instance of [HttpServer] as the `requests` parameter in
-/// [serveRequests].
+/// [serveRequestsGuarded].
 ///
 /// This adapter supports request hijacking; see [Request.hijack]. It also
 /// supports the `"shelf.io.buffer_output"` `Response.context` property. If this
@@ -34,7 +36,7 @@ export 'src/io_server.dart' show IOServer;
 /// Serve a [Stream] of [HttpRequest]s with error handling.
 ///
 /// [HttpServer] implements [Stream<HttpRequest>] so it can be passed directly
-/// to [serveRequests].
+/// to [serveRequestsGuarded].
 ///
 /// Serves requests in an error zone, using [onError] to handle errors.
 ///
@@ -104,6 +106,7 @@ Future<HttpServer> serve(
 /// console and cause a 500 response with no body. Errors thrown asynchronously
 /// by [handler] will be printed to the console or, if there's an active error
 /// zone, passed to that zone.
+@Deprecated('Use serveRequestsGuarded')
 void serveRequests(Stream<HttpRequest> requests, Handler handler) {
   catchTopLevelErrors(() {
     requests.listen((request) => handleRequest(request, handler));

--- a/lib/src/io_server.dart
+++ b/lib/src/io_server.dart
@@ -52,7 +52,9 @@ class IOServer implements Server {
     }
     _mounted = true;
 
-    serveRequests(server, handler);
+    serveRequestsGuarded(server, handler, (e, s) {
+      print('IOServer: error serving requests:\n$e:$s');
+    });
   }
 
   @override

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -13,8 +13,8 @@ import 'shelf_unmodifiable_map.dart';
 /// If [this] is called in a non-root error zone, it will just run [callback]
 /// and return the result. Otherwise, it will capture any errors using
 /// [runZoned] and pass them to [onError].
-void catchTopLevelErrors(void Function() callback,
-    void Function(dynamic error, StackTrace) onError) {
+void catchTopLevelErrors(
+    void Function() callback, void Function(Object error, StackTrace) onError) {
   if (Zone.current.inSameErrorZone(Zone.root)) {
     return runZonedGuarded(callback, onError);
   } else {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf
-version: 1.2.1-dev
+version: 1.3.0-dev
 description: >-
   A model for web server middleware that encourages composition and easy reuse
 repository: https://github.com/dart-lang/shelf


### PR DESCRIPTION
`serveRequests` does not always wrap listening to http requests in a `runZoneGuarded` wrap.

This leads to hard to debug async exceptions later if something up its call chain adds its own
 `runZoneGuarded` wrapper - in that case exceptions stop being caught and ignored inside
 `serveRequests` and fall to the next root zone exception handler, which unexpectedly changes
the logic of the calling code.

Note that adding such top level handler will change behavior of all `serveRequests` calls,
including the ones coming from imported libraries, which makes fixing those new issues
particularly complicated.

This change adds two new APIs, `serveGuarded` and `serveRequestsGuarded`, that alleviate
the issue by always serving requests in an error zone and enabling the user to provide
 an error handler. A simple print-and-continue error handler is used by default.

In addition, updated the message on the default error handler to reflect source of the
errors.

Closes: https://github.com/dart-lang/shelf/issues/202