### PR TITLE
Drop redundant language version markers

### DIFF
--- a/pkgs/shelf_router_generator/CHANGELOG.md
+++ b/pkgs/shelf_router_generator/CHANGELOG.md
@@ -1,3 +1,5 @@
+## v1.0.3-dev
+
 ## v1.0.2
 
 * Support update-to-date dependencies.

--- a/pkgs/shelf_router_generator/example/main.dart
+++ b/pkgs/shelf_router_generator/example/main.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// @dart=2.12
-
 import 'dart:async' show Future;
 
 import 'package:shelf/shelf.dart';

--- a/pkgs/shelf_router_generator/example/main.g.dart
+++ b/pkgs/shelf_router_generator/example/main.g.dart
@@ -1,5 +1,4 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// @dart=2.12
 
 part of 'main.dart';
 

--- a/pkgs/shelf_router_generator/pubspec.yaml
+++ b/pkgs/shelf_router_generator/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf_router_generator
-version: 1.0.2
+version: 1.0.3-dev
 description: >
   A package:build compatible builder for generating request routers for the
   shelf web-framework based on source annotations.

--- a/pkgs/shelf_router_generator/test/server/api.dart
+++ b/pkgs/shelf_router_generator/test/server/api.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// @dart=2.12
-
 import 'dart:async' show Future;
 import 'package:shelf/shelf.dart';
 import 'package:shelf_router/shelf_router.dart';

--- a/pkgs/shelf_router_generator/test/server/api.g.dart
+++ b/pkgs/shelf_router_generator/test/server/api.g.dart
@@ -1,5 +1,4 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// @dart=2.12
 
 part of 'api.dart';
 

--- a/pkgs/shelf_router_generator/test/server/server.dart
+++ b/pkgs/shelf_router_generator/test/server/server.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// @dart=2.12
-
 import 'dart:async' show Future;
 import 'dart:io' show HttpServer;
 

--- a/pkgs/shelf_router_generator/test/server/service.dart
+++ b/pkgs/shelf_router_generator/test/server/service.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// @dart=2.12
-
 import 'dart:async' show Future, FutureOr;
 
 import 'package:shelf/shelf.dart';

--- a/pkgs/shelf_router_generator/test/server/service.g.dart
+++ b/pkgs/shelf_router_generator/test/server/service.g.dart
@@ -1,5 +1,4 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// @dart=2.12
 
 part of 'service.dart';
 

--- a/pkgs/shelf_router_generator/test/server/unrelatedannotation.dart
+++ b/pkgs/shelf_router_generator/test/server/unrelatedannotation.dart
@@ -1,5 +1,3 @@
-// @dart=2.12
-
 /// Annotation for an API end-point.
 class EndPoint {
   /// HTTP verb for requests routed to the annotated method.

--- a/pkgs/shelf_router_generator/test/server_test.dart
+++ b/pkgs/shelf_router_generator/test/server_test.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// @dart=2.12
-
 import 'package:http/http.dart' as http;
 import 'package:test/test.dart';
 


### PR DESCRIPTION
This package depends on version `2.12` of the SDK so specifying this
language version is unnecessary.
