### PR TITLE
Fix repository url in shelf_router and shelf_router_generator

### DIFF
--- a/pkgs/shelf_router/pubspec.yaml
+++ b/pkgs/shelf_router/pubspec.yaml
@@ -3,16 +3,17 @@ version: 1.1.2
 description: >
   A convinent request router for the shelf web-framework, with support for
   URL-parameters, nested routers and routers generated from source annotations.
-homepage: https://github.com/google/dart-neats/tree/master/shelf_router
-repository: https://github.com/google/dart-neats.git
-issue_tracker: https://github.com/google/dart-neats/labels/pkg:shelf_router
+repository: https://github.com/dart-lang/shelf/tree/master/pkgs/shelf_router
+
+environment:
+  sdk: '>=2.12.0 <3.0.0'
+
 dependencies:
   meta: ^1.3.0
   shelf: ^1.0.0
   http_methods: ^1.1.0
+
 dev_dependencies:
   test: ^1.16.0
   lints: ^1.0.0
   http: ^0.13.0
-environment:
-  sdk: '>=2.12.0 <3.0.0'

--- a/pkgs/shelf_router_generator/pubspec.yaml
+++ b/pkgs/shelf_router_generator/pubspec.yaml
@@ -3,9 +3,10 @@ version: 1.0.3-dev
 description: >
   A package:build compatible builder for generating request routers for the
   shelf web-framework based on source annotations.
-homepage: https://github.com/google/dart-neats/tree/master/shelf_router_generator
-repository: https://github.com/google/dart-neats.git
-issue_tracker: https://github.com/google/dart-neats/labels/pkg:shelf_router_generator
+repository: https://github.com/dart-lang/shelf/tree/master/pkgs/shelf_router_generator
+
+environment:
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   analyzer: '>=2.0.0 <4.0.0'
@@ -23,6 +24,3 @@ dev_dependencies:
   http: ^0.13.0
   lints: ^1.0.0
   test: ^1.5.3
-
-environment:
-  sdk: '>=2.12.0 <3.0.0'


### PR DESCRIPTION
This pull request corrects the repository url in pubspec.yaml of shelf_router and shelf_router_generator after both projects were transferred from [dart_neats] (https://github.com/google/dart-neats) to this repository. 

I deleted the two configurations `homepage` and `issue_tracker` as they are not present in other shelf packages either. 