### PR TITLE
prep for publishing the shelf packages

### DIFF
--- a/pkgs/shelf/CHANGELOG.md
+++ b/pkgs/shelf/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 1.3.1-dev
+## 1.3.1
+
+* Update the pubspec `repository` field.
 
 ## 1.3.0
 

--- a/pkgs/shelf/pubspec.yaml
+++ b/pkgs/shelf/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf
-version: 1.3.1-dev
+version: 1.3.1
 description: >
   A model for web server middleware that encourages composition and easy reuse.
 repository: https://github.com/dart-lang/shelf/tree/master/pkgs/shelf

--- a/pkgs/shelf_packages_handler/CHANGELOG.md
+++ b/pkgs/shelf_packages_handler/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 3.0.1-dev
+## 3.0.1
 
-- Require Dart `2.14`.
+* Require Dart `2.14`.
+* Update the pubspec `repository` field.
 
 ## 3.0.0
 

--- a/pkgs/shelf_packages_handler/pubspec.yaml
+++ b/pkgs/shelf_packages_handler/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf_packages_handler
-version: 3.0.1-dev
+version: 3.0.1
 description: A shelf handler for serving a `packages/` directory.
 repository: https://github.com/dart-lang/shelf/tree/master/pkgs/shelf_packages_handler
 

--- a/pkgs/shelf_proxy/CHANGELOG.md
+++ b/pkgs/shelf_proxy/CHANGELOG.md
@@ -1,15 +1,17 @@
-## 1.0.2-dev
+## 1.0.2
+
+* Update the pubspec `repository` field.
 
 ## 1.0.1
 
-- Drop dependency on `package:pedantic`.
-- Require Dart `2.14`.
+* Drop dependency on `package:pedantic`.
+* Require Dart `2.14`.
 
 ## 1.0.0
 
-- Require Dart `2.12`.
-- Enable null safety.
-- Removed deprecated `createProxyHandler`.
+* Require Dart `2.12`.
+* Enable null safety.
+* Removed deprecated `createProxyHandler`.
 
 ## 0.1.0+7
 

--- a/pkgs/shelf_proxy/pubspec.yaml
+++ b/pkgs/shelf_proxy/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf_proxy
-version: 1.0.2-dev
+version: 1.0.2
 description: A shelf handler for proxying HTTP requests to another server.
 repository: https://github.com/dart-lang/shelf/tree/master/pkgs/shelf_proxy
 

--- a/pkgs/shelf_router/CHANGELOG.md
+++ b/pkgs/shelf_router/CHANGELOG.md
@@ -1,19 +1,23 @@
+## 1.1.3
+
+* Update the pubspec `repository` field.
+
 ## v1.1.2
 
-  * Remove trailing slash requirement when using `mount`.
+* Remove trailing slash requirement when using `mount`.
 
 ## v1.1.1
 
- * Fix `Router.routeNotFound` to enable multiple `read()` calls on it.
+* Fix `Router.routeNotFound` to enable multiple `read()` calls on it.
 
 ## v1.1.0
- * `params` is deprecated in favor of `Request.params` adding using an extension
-   on `Request`.
- * The default `notFoundHandler` now returns a sentinel `routeNotFound` response
-   object which causes 404 with the message 'Route not found'.
- * __Minor breaking__: Handlers and sub-routers that return the sentinel
-   `routeNotFound` response object will be ignored and pattern matching will
-   continue on additional routes/handlers.
+* `params` is deprecated in favor of `Request.params` adding using an extension
+    on `Request`.
+* The default `notFoundHandler` now returns a sentinel `routeNotFound` response
+    object which causes 404 with the message 'Route not found'.
+* __Minor breaking__: Handlers and sub-routers that return the sentinel
+    `routeNotFound` response object will be ignored and pattern matching will
+    continue on additional routes/handlers.
 
 Changing the router to continue pattern matching additional routes if a matched
 _handler_ or _nested router_ returns the sentinel `routeNotFound` response

--- a/pkgs/shelf_router/pubspec.yaml
+++ b/pkgs/shelf_router/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf_router
-version: 1.1.2
+version: 1.1.3
 description: >
   A convinent request router for the shelf web-framework, with support for
   URL-parameters, nested routers and routers generated from source annotations.

--- a/pkgs/shelf_router_generator/CHANGELOG.md
+++ b/pkgs/shelf_router_generator/CHANGELOG.md
@@ -1,4 +1,6 @@
-## v1.0.3-dev
+## v1.0.3
+
+* Update the pubspec `repository` field.
 
 ## v1.0.2
 
@@ -10,9 +12,9 @@
 
 ## v1.0.0
 
- * Support update-to-date dependencies.
- * Migrate implementation to null safety.
- * Generate null-safe code.
+* Support update-to-date dependencies.
+* Migrate implementation to null safety.
+* Generate null-safe code.
 
 ## v0.7.2+4
 

--- a/pkgs/shelf_router_generator/pubspec.yaml
+++ b/pkgs/shelf_router_generator/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf_router_generator
-version: 1.0.3-dev
+version: 1.0.3
 description: >
   A package:build compatible builder for generating request routers for the
   shelf web-framework based on source annotations.

--- a/pkgs/shelf_static/CHANGELOG.md
+++ b/pkgs/shelf_static/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 1.1.1-dev
+## 1.1.1
 
-- Require Dart `2.14`.
+* Require Dart `2.14`.
+* Update the pubspec `repository` field.
 
 ## 1.1.0
 

--- a/pkgs/shelf_static/pubspec.yaml
+++ b/pkgs/shelf_static/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf_static
-version: 1.1.1-dev
+version: 1.1.1
 description: Static file server support for the shelf package and ecosystem.
 repository: https://github.com/dart-lang/shelf/tree/master/pkgs/shelf_static
 

--- a/pkgs/shelf_test_handler/CHANGELOG.md
+++ b/pkgs/shelf_test_handler/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 2.0.1-dev
+## 2.0.1
 
-- Require Dart `2.14`.
+* Require Dart `2.14`.
+* Update the pubspec `repository` field.
 
 ## 2.0.0
 

--- a/pkgs/shelf_test_handler/pubspec.yaml
+++ b/pkgs/shelf_test_handler/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf_test_handler
-version: 2.0.1-dev
+version: 2.0.1
 description: A Shelf handler that makes it easy to test HTTP interactions.
 repository: https://github.com/dart-lang/shelf/tree/master/pkgs/shelf_test_handler
 

--- a/pkgs/shelf_web_socket/CHANGELOG.md
+++ b/pkgs/shelf_web_socket/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 1.0.2-dev
+## 1.0.2
 
-- Require Dart `2.14`.
+* Require Dart `2.14`.
+* Update the pubspec `repository` field.
 
 ## 1.0.1
 

--- a/pkgs/shelf_web_socket/pubspec.yaml
+++ b/pkgs/shelf_web_socket/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf_web_socket
-version: 1.0.2-dev
+version: 1.0.2
 description: >
   A shelf handler that wires up a listener for every connection.
 repository: https://github.com/dart-lang/shelf/tree/master/pkgs/shelf_web_socket


### PR DESCRIPTION
Prep for publishing the shelf packages:
- rev all the versions (and check that they are the correct patch versions from last published)
- make sure there is content in the latest changelog entries
- some minor normalization of the most recent changelog entries
