### PR TITLE
Changed advertised server technology response header

### DIFF
--- a/pkgs/shelf/CHANGELOG.md
+++ b/pkgs/shelf/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.3.2
+
+* `shelf_io.dart`
+    * Started setting `X-Powered-By` response header
+      to `Dart with package:shelf`.
+    * Stopped setting `Server` header (with value `dart:io with Shelf`).
+
 ## 1.3.1
 
 * Update the pubspec `repository` field.

--- a/pkgs/shelf/lib/shelf_io.dart
+++ b/pkgs/shelf/lib/shelf_io.dart
@@ -217,8 +217,9 @@ Future<void> _writeResponse(Response response, HttpResponse httpResponse) {
     httpResponse.headers.set(HttpHeaders.transferEncodingHeader, 'chunked');
   }
 
-  if (!response.headers.containsKey(HttpHeaders.serverHeader)) {
-    httpResponse.headers.set(HttpHeaders.serverHeader, 'dart:io with Shelf');
+  if (!response.headers.containsKey(_xPoweredByResponseHeader)) {
+    httpResponse.headers
+        .set(_xPoweredByResponseHeader, 'Dart with package:shelf');
   }
 
   if (!response.headers.containsKey(HttpHeaders.dateHeader)) {
@@ -229,6 +230,11 @@ Future<void> _writeResponse(Response response, HttpResponse httpResponse) {
       .addStream(response.read())
       .then((_) => httpResponse.close());
 }
+
+/// Common header to advertise the server technology being used.
+///
+/// See https://webtechsurvey.com/response-header/x-powered-by
+const _xPoweredByResponseHeader = 'X-Powered-By';
 
 // TODO(kevmoo) A developer mode is needed to include error info in response
 // TODO(kevmoo) Make error output plugable. stderr, logging, etc

--- a/pkgs/shelf/pubspec.yaml
+++ b/pkgs/shelf/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf
-version: 1.3.1
+version: 1.3.2
 description: >
   A model for web server middleware that encourages composition and easy reuse.
 repository: https://github.com/dart-lang/shelf/tree/master/pkgs/shelf

--- a/pkgs/shelf/test/shelf_io_test.dart
+++ b/pkgs/shelf/test/shelf_io_test.dart
@@ -353,24 +353,25 @@ void main() {
     });
   });
 
-  group('server header', () {
-    test('defaults to "dart:io with Shelf"', () async {
+  group('X-Powered-By header', () {
+    const poweredBy = 'x-powered-by';
+    test('defaults to "Dart with package:shelf"', () async {
       await _scheduleServer(syncHandler);
 
       var response = await _get();
-      expect(response.headers,
-          containsPair(HttpHeaders.serverHeader, 'dart:io with Shelf'));
+      expect(
+        response.headers,
+        containsPair(poweredBy, 'Dart with package:shelf'),
+      );
     });
 
     test('defers to header in response', () async {
       await _scheduleServer((request) {
-        return Response.ok('test',
-            headers: {HttpHeaders.serverHeader: 'myServer'});
+        return Response.ok('test', headers: {poweredBy: 'myServer'});
       });
 
       var response = await _get();
-      expect(
-          response.headers, containsPair(HttpHeaders.serverHeader, 'myServer'));
+      expect(response.headers, containsPair(poweredBy, 'myServer'));
     });
   });
 


### PR DESCRIPTION
was: Server -> dart:io with Self
now: X-Powered-By -> Dart with package:shelf

Will make it easier to detect pkg:shelf when used on cloud providers, etc
