### PR TITLE
Move ignores for deprecated members to in-place comments

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -5,8 +5,6 @@ analyzer:
     strict-casts: true
     strict-inference: true
     strict-raw-types: true
-  errors:
-    deprecated_member_use_from_same_package: ignore
 
 linter:
   rules:

--- a/pkgs/shelf/lib/shelf.dart
+++ b/pkgs/shelf/lib/shelf.dart
@@ -13,4 +13,5 @@ export 'src/pipeline.dart' show Pipeline;
 export 'src/request.dart' show Request;
 export 'src/response.dart' show Response;
 export 'src/server.dart' show Server;
+// ignore: deprecated_member_use_from_same_package
 export 'src/server_handler.dart' show ServerHandler;

--- a/pkgs/shelf/lib/src/server_handler.dart
+++ b/pkgs/shelf/lib/src/server_handler.dart
@@ -57,6 +57,7 @@ class ServerHandler {
   }
 }
 
+// ignore: deprecated_member_use_from_same_package
 /// The [Server] returned by [ServerHandler].
 class _HandlerServer implements Server {
   @override

--- a/pkgs/shelf/test/server_handler_test.dart
+++ b/pkgs/shelf/test/server_handler_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore_for_file: deprecated_member_use_from_same_package
+
 import 'dart:async';
 
 import 'package:shelf/shelf.dart';


### PR DESCRIPTION
Ensure others don't sneak in because of one API
