### PR TITLE
adapter for flutter web or dart web

### DIFF
--- a/pkgs/shelf_proxy/CHANGELOG.md
+++ b/pkgs/shelf_proxy/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.3
+
+* Add cross domain request support, use truly request method from 'Access-Control-Request-Method'
+
 ## 1.0.2
 
 * Update the pubspec `repository` field.

--- a/pkgs/shelf_proxy/lib/shelf_proxy.dart
+++ b/pkgs/shelf_proxy/lib/shelf_proxy.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
@@ -40,7 +41,15 @@ Handler proxyHandler(Object url, {http.Client? client, String? proxyName}) {
     // TODO(nweiz): Handle TRACE requests correctly. See
     // http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.8
     final requestUrl = uri.resolve(serverRequest.url.toString());
-    final clientRequest = http.StreamedRequest(serverRequest.method, requestUrl)
+
+    // To use truely request method, not the one from the serverRequest
+    // In flutter web's cross domain request, serverRequest.method is OPTIONS,
+    // but the real request method is POST or GET or others.
+    final method = serverRequest.headers[
+      HttpHeaders.accessControlRequestMethodHeader
+    ] ?? serverRequest.method;
+
+    final clientRequest = http.StreamedRequest(method, requestUrl)
       ..followRedirects = false
       ..headers.addAll(serverRequest.headers)
       ..headers['Host'] = uri.authority;

--- a/pkgs/shelf_proxy/pubspec.yaml
+++ b/pkgs/shelf_proxy/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf_proxy
-version: 1.0.2
+version: 1.0.3
 description: A shelf handler for proxying HTTP requests to another server.
 repository: https://github.com/dart-lang/shelf/tree/master/pkgs/shelf_proxy
 


### PR DESCRIPTION
In web's cross domain request, serverRequest.method is OPTIONS.
In Dart Server, we need to use the truly request from user.
And this truly method is come from http-header:'Access-Control-Request-Method', such as POST/GET etc.

The doc is here : https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request

My PR doesn't effect normal request, no cross domain request，it will use serverRequest.method. Please Review it, thanks.
@kevmoo @natebosch 
