### PR TITLE
Fix doc comment references

### DIFF
--- a/pkgs/shelf/README.md
+++ b/pkgs/shelf/README.md
@@ -124,7 +124,7 @@ to capture only errors that would otherwise be top-leveled:
 ```dart
 /// Run [callback] and capture any errors that would otherwise be top-leveled.
 ///
-/// If [this] is called in a non-root error zone, it will just run [callback]
+/// If `this` is called in a non-root error zone, it will just run [callback]
 /// and return the result. Otherwise, it will capture any errors using
 /// [runZoned] and pass them to [onError].
 void catchTopLevelErrors(

--- a/pkgs/shelf/lib/src/middleware/add_chunked_encoding.dart
+++ b/pkgs/shelf/lib/src/middleware/add_chunked_encoding.dart
@@ -7,18 +7,17 @@ import 'package:http_parser/http_parser.dart';
 
 import '../middleware.dart';
 
-/// Middleware that adds [chunked transfer coding][] to responses if none of the
-/// following conditions are true:
-///
-/// [chunked transfer coding]: https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.6.1
+/// Middleware that adds
+/// [chunked transfer coding](https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.6.1)
+/// to a responses if none of the following conditions are true:
 ///
 /// * A Content-Length header is provided.
 /// * The Content-Type header indicates the MIME type `multipart/byteranges`.
 /// * The Transfer-Encoding header already includes the `chunked` coding.
 ///
-/// This is intended for use by [Shelf adapters][] rather than end-users.
-///
-/// [Shelf adapters]: https://github.com/dart-lang/shelf#adapters
+/// This is intended for use by
+/// [Shelf adapters](https://github.com/dart-lang/shelf#adapters) rather than
+/// end-users.
 final addChunkedEncoding = createMiddleware(responseHandler: (response) {
   if (response.contentLength != null) return response;
   if (response.statusCode < 200) return response;

--- a/pkgs/shelf/lib/src/middleware/add_chunked_encoding.dart
+++ b/pkgs/shelf/lib/src/middleware/add_chunked_encoding.dart
@@ -16,7 +16,7 @@ import '../middleware.dart';
 /// * The Transfer-Encoding header already includes the `chunked` coding.
 ///
 /// This is intended for use by
-/// [Shelf adapters](https://github.com/dart-lang/shelf#adapters) rather than
+/// [Shelf adapters](https://pub.dev/packages/shelf#adapters) rather than
 /// end-users.
 final addChunkedEncoding = createMiddleware(responseHandler: (response) {
   if (response.contentLength != null) return response;

--- a/pkgs/shelf/lib/src/request.dart
+++ b/pkgs/shelf/lib/src/request.dart
@@ -294,9 +294,9 @@ class _OnHijack {
 
   _OnHijack(this._callback);
 
-  /// Calls [this].
+  /// Calls `this`.
   ///
-  /// Throws a [StateError] if [this] has already been called.
+  /// Throws a [StateError] if `this` has already been called.
   void run(void Function(StreamChannel<List<int>>) callback) {
     if (called) throw StateError('This request has already been hijacked.');
     called = true;

--- a/pkgs/shelf/lib/src/util.dart
+++ b/pkgs/shelf/lib/src/util.dart
@@ -10,7 +10,7 @@ import 'shelf_unmodifiable_map.dart';
 
 /// Run [callback] and capture any errors that would otherwise be top-leveled.
 ///
-/// If [this] is called in a non-root error zone, it will just run [callback]
+/// If `this` is called in a non-root error zone, it will just run [callback]
 /// and return the result. Otherwise, it will capture any errors using
 /// [runZoned] and pass them to [onError].
 void catchTopLevelErrors(void Function() callback,

--- a/pkgs/shelf_router_generator/lib/src/shelf_router_generator.dart
+++ b/pkgs/shelf_router_generator/lib/src/shelf_router_generator.dart
@@ -34,7 +34,7 @@ const _responseType = g.TypeChecker.fromRuntime(shelf.Response);
 const _requestType = g.TypeChecker.fromRuntime(shelf.Request);
 const _stringType = g.TypeChecker.fromRuntime(String);
 
-/// A representation of a handler that was annotated with [Route].
+/// A representation of a handler that was annotated with [shelf_router.Route].
 class _Handler {
   final String verb, route;
   final ExecutableElement element;

--- a/pkgs/shelf_test_handler/lib/src/expectation.dart
+++ b/pkgs/shelf_test_handler/lib/src/expectation.dart
@@ -6,10 +6,10 @@ import 'package:shelf/shelf.dart';
 
 /// A single expectation for an HTTP request sent to a [ShelfTestHandler].
 class Expectation {
-  /// The expected request method, or [null] if this allows any requests.
+  /// The expected request method, or `null` if this allows any requests.
   final String? method;
 
-  /// The expected request path, or [null] if this allows any requests.
+  /// The expected request path, or `null` if this allows any requests.
   final String? path;
 
   /// The handler to use for requests that match this expectation.

--- a/pkgs/shelf_test_handler/lib/src/handler.dart
+++ b/pkgs/shelf_test_handler/lib/src/handler.dart
@@ -39,7 +39,7 @@ class ShelfTestHandler {
         _zone = Zone.current;
 
   /// Expects that a single HTTP request with the given [method] and [path] will
-  /// be made to [this].
+  /// be made to `this`.
   ///
   /// The [path] should be root-relative; that is, it shuld start with "/".
   ///
@@ -51,7 +51,7 @@ class ShelfTestHandler {
     _expectations.add(Expectation(method, path, handler));
   }
 
-  /// Expects that a single HTTP request will be made to [this].
+  /// Expects that a single HTTP request will be made to `this`.
   ///
   /// When a request is made, [handler] is used to handle that request.
   ///


### PR DESCRIPTION
Most importantly, the link to `addChunkedEncoding` which was invalid
The others are handled fine by dartdoc, but cause warnings with
the `comment_references` lint.
