### PR TITLE
Making the response method consistent

### DIFF
--- a/pkgs/shelf/lib/src/response.dart
+++ b/pkgs/shelf/lib/src/response.dart
@@ -167,8 +167,8 @@ class Response extends Message {
   /// This indicates that the server has received a malformed request.
   ///
   /// {@macro shelf_response_body_and_encoding_param}
-  Response.badRequest({
-    Object? body,
+  Response.badRequest(
+    Object? body, {
     Map<String, /* String | List<String> */ Object>? headers,
     Encoding? encoding,
     Map<String, Object>? context,
@@ -242,8 +242,8 @@ class Response extends Message {
   /// from fulfilling the request.
   ///
   /// {@macro shelf_response_body_and_encoding_param}
-  Response.internalServerError({
-    Object? body,
+  Response.internalServerError(
+    Object? body, {
     Map<String, /* String | List<String> */ Object>? headers,
     Encoding? encoding,
     Map<String, Object>? context,


### PR DESCRIPTION
The methods ok, unauthorized, forbidden, notFound first have body as a parameter, and then the other parameters must be defined, 

The methods internalServerError and badRequest are different, all parameters are in {}

What you might be able to do is to change the parameter definition of the anadere method?

- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
