### PR TITLE
Add command line arguments to all examples. Were already on some.

### DIFF
--- a/pkgs/shelf/example/example.dart
+++ b/pkgs/shelf/example/example.dart
@@ -2,14 +2,34 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
+import 'package:args/args.dart';
 import 'package:shelf/shelf.dart';
 import 'package:shelf/shelf_io.dart' as shelf_io;
 
-void main() async {
+void main(List<String> args) async {
+  final parser = _getParser();
+
+  String address;
+  int port;
+  try {
+    final result = parser.parse(args);
+    address = result['address'] as String;
+    port = int.parse(result['port'] as String);
+  } on FormatException catch (e) {
+    stderr
+      ..writeln(e.message)
+      ..writeln(parser.usage);
+    // http://linux.die.net/include/sysexits.h
+    // #define EX_USAGE	64	/* command line usage error */
+    exit(64);
+  }
+
   var handler =
       const Pipeline().addMiddleware(logRequests()).addHandler(_echoRequest);
 
-  var server = await shelf_io.serve(handler, 'localhost', 8080);
+  var server = await shelf_io.serve(handler, address, port);
 
   // Enable content compression
   server.autoCompress = true;
@@ -19,3 +39,8 @@ void main() async {
 
 Response _echoRequest(Request request) =>
     Response.ok('Request for "${request.url}"');
+
+ArgParser _getParser() => ArgParser()
+  ..addOption('port', abbr: 'p', defaultsTo: '8080', help: 'Port to listen on')
+  ..addOption('address',
+      abbr: 'a', defaultsTo: 'localhost', help: 'Address to listen on');

--- a/pkgs/shelf/pubspec.yaml
+++ b/pkgs/shelf/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   stream_channel: ^2.1.0
 
 dev_dependencies:
+  args: ^2.0.0
   dart_flutter_team_lints: ^2.0.0
   http: '>=0.13.0 <2.0.0'
   test: ^1.16.0

--- a/pkgs/shelf_proxy/example/example.dart
+++ b/pkgs/shelf_proxy/example/example.dart
@@ -2,15 +2,45 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
+import 'package:args/args.dart';
 import 'package:shelf/shelf_io.dart' as shelf_io;
 import 'package:shelf_proxy/shelf_proxy.dart';
 
-Future<void> main() async {
+Future<void> main(List<String> args) async {
+  final parser = _getParser();
+
+  String address;
+  int port;
+  String targetAddress;
+  try {
+    final result = parser.parse(args);
+    address = result['address'] as String;
+    port = int.parse(result['port'] as String);
+    targetAddress = result['targetAddress'] as String;
+  } on FormatException catch (e) {
+    stderr
+      ..writeln(e.message)
+      ..writeln(parser.usage);
+    // http://linux.die.net/include/sysexits.h
+    // #define EX_USAGE	64	/* command line usage error */
+    exit(64);
+  }
+
   final server = await shelf_io.serve(
-    proxyHandler('https://dart.dev'),
-    'localhost',
-    8080,
+    proxyHandler(targetAddress),
+    address,
+    port,
   );
 
-  print('Proxying at http://${server.address.host}:${server.port}');
+  print(
+      'Proxying for $targetAddress at http://${server.address.host}:${server.port}');
 }
+
+ArgParser _getParser() => ArgParser()
+  ..addOption('port', abbr: 'p', defaultsTo: '8080', help: 'Port to listen on')
+  ..addOption('address',
+      abbr: 'a', defaultsTo: 'localhost', help: 'Address to listen on')
+  ..addOption('targetAddress',
+      abbr: 't', defaultsTo: 'https://dart.dev', help: 'Address proxying for');

--- a/pkgs/shelf_proxy/pubspec.yaml
+++ b/pkgs/shelf_proxy/pubspec.yaml
@@ -16,5 +16,6 @@ dependencies:
   shelf: ^1.0.0
 
 dev_dependencies:
+  args: ^2.0.0
   dart_flutter_team_lints: ^2.0.0
   test: ^1.6.0

--- a/pkgs/shelf_router/example/main.dart
+++ b/pkgs/shelf_router/example/main.dart
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 import 'dart:async' show Future;
+import 'dart:io';
 
+import 'package:args/args.dart';
 import 'package:shelf/shelf.dart';
 import 'package:shelf/shelf_io.dart' as shelf_io;
 import 'package:shelf_router/shelf_router.dart';
@@ -79,8 +81,30 @@ class Api {
 }
 
 // Run shelf server and host a [Service] instance on port 8080.
-void main() async {
+void main(List<String> args) async {
+  final parser = _getParser();
+
+  String address;
+  int port;
+  try {
+    final result = parser.parse(args);
+    address = result['address'] as String;
+    port = int.parse(result['port'] as String);
+  } on FormatException catch (e) {
+    stderr
+      ..writeln(e.message)
+      ..writeln(parser.usage);
+    // http://linux.die.net/include/sysexits.h
+    // #define EX_USAGE	64	/* command line usage error */
+    exit(64);
+  }
+
   final service = Service();
-  final server = await shelf_io.serve(service.handler, 'localhost', 8080);
+  final server = await shelf_io.serve(service.handler, address, port);
   print('Server running on localhost:${server.port}');
 }
+
+ArgParser _getParser() => ArgParser()
+  ..addOption('port', abbr: 'p', defaultsTo: '8080', help: 'Port to listen on')
+  ..addOption('address',
+      abbr: 'a', defaultsTo: 'localhost', help: 'Address to listen on');

--- a/pkgs/shelf_router/pubspec.yaml
+++ b/pkgs/shelf_router/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   shelf: ^1.0.0
 
 dev_dependencies:
+  args: ^2.0.0
   dart_flutter_team_lints: ^2.0.0
   http: '>=0.13.0 <2.0.0'
   test: ^1.16.0

--- a/pkgs/shelf_router_generator/example/main.dart
+++ b/pkgs/shelf_router_generator/example/main.dart
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 import 'dart:async' show Future;
+import 'dart:io';
 
+import 'package:args/args.dart';
 import 'package:shelf/shelf.dart';
 import 'package:shelf/shelf_io.dart' as shelf_io;
 import 'package:shelf_router/shelf_router.dart';
@@ -73,8 +75,30 @@ class Api {
 }
 
 // Run shelf server and host a [Service] instance on port 8080.
-void main() async {
+void main(List<String> args) async {
+  final parser = _getParser();
+
+  String address;
+  int port;
+  try {
+    final result = parser.parse(args);
+    address = result['address'] as String;
+    port = int.parse(result['port'] as String);
+  } on FormatException catch (e) {
+    stderr
+      ..writeln(e.message)
+      ..writeln(parser.usage);
+    // http://linux.die.net/include/sysexits.h
+    // #define EX_USAGE	64	/* command line usage error */
+    exit(64);
+  }
+
   final service = Service();
-  final server = await shelf_io.serve(service.handler, 'localhost', 8080);
+  final server = await shelf_io.serve(service.handler, address, port);
   print('Server running on localhost:${server.port}');
 }
+
+ArgParser _getParser() => ArgParser()
+  ..addOption('port', abbr: 'p', defaultsTo: '8080', help: 'Port to listen on')
+  ..addOption('address',
+      abbr: 'a', defaultsTo: 'localhost', help: 'Address to listen on');

--- a/pkgs/shelf_router_generator/pubspec.yaml
+++ b/pkgs/shelf_router_generator/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
   source_gen: ^1.0.0
 
 dev_dependencies:
+  args: ^2.0.0
   build_runner: ^2.0.0
   build_verify: ^3.0.0
   dart_flutter_team_lints: ^2.0.0

--- a/pkgs/shelf_static/example/example.dart
+++ b/pkgs/shelf_static/example/example.dart
@@ -11,12 +11,14 @@ import 'package:shelf_static/shelf_static.dart';
 void main(List<String> args) {
   final parser = _getParser();
 
+  String address;
   int port;
   bool logging;
   bool listDirectories;
 
   try {
     final result = parser.parse(args);
+    address = result['address'] as String;
     port = int.parse(result['port'] as String);
     logging = result['logging'] as bool;
     listDirectories = result['list-directories'] as bool;
@@ -47,14 +49,16 @@ void main(List<String> args) {
   final handler = pipeline.addHandler(createStaticHandler('example/files',
       defaultDocument: defaultDoc, listDirectories: listDirectories));
 
-  io.serve(handler, 'localhost', port).then((server) {
+  io.serve(handler, address, port).then((server) {
     print('Serving at http://${server.address.host}:${server.port}');
   });
 }
 
 ArgParser _getParser() => ArgParser()
-  ..addFlag('logging', abbr: 'l', defaultsTo: true)
-  ..addOption('port', abbr: 'p', defaultsTo: '8080')
+  ..addFlag('logging', abbr: 'l', defaultsTo: true, help: 'Enable logging')
+  ..addOption('port', abbr: 'p', defaultsTo: '8080', help: 'Port to listen on')
+  ..addOption('address',
+      abbr: 'a', defaultsTo: 'localhost', help: 'Address to listen on')
   ..addFlag('list-directories',
       abbr: 'f',
       negatable: false,


### PR DESCRIPTION
- Add command line arguments to all shelf example programs. 

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>

- One of the examples already had command line arguments.  I rationalized all the example programs taking the same arguments and adding one in one case.
- Commandline arguments are cool. They clutter the examples but make them more flexible.
- Not fixed:  Some of the example programs are `example.dart`.  Others are `main.dart`

</details>
