### PR TITLE
Remove `dependency_overrides`

### DIFF
--- a/pkgs/shelf_web_socket/CHANGELOG.md
+++ b/pkgs/shelf_web_socket/CHANGELOG.md
@@ -1,8 +1,5 @@
 ## 2.0.1-wip
 
-* Replace `dependency_overrides` on `package:test` `1.25.2` with a
-  `dev_dependencies` on that package version.
-
 ## 2.0.0
 
 * Require Dart `^3.0.0`.

--- a/pkgs/shelf_web_socket/CHANGELOG.md
+++ b/pkgs/shelf_web_socket/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.1-wip
+
+* Replace `dependency_overrides` on `package:test` `1.25.2` with a
+  `dev_dependencies` on that package version.
+
 ## 2.0.0
 
 * Require Dart `^3.0.0`.

--- a/pkgs/shelf_web_socket/pubspec.yaml
+++ b/pkgs/shelf_web_socket/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf_web_socket
-version: 2.0.0-wip
+version: 2.0.1-wip
 description: >
   A shelf handler that wires up a listener for every connection.
 repository: https://github.com/dart-lang/shelf/tree/master/pkgs/shelf_web_socket

--- a/pkgs/shelf_web_socket/pubspec.yaml
+++ b/pkgs/shelf_web_socket/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf_web_socket
-version: 2.0.0
+version: 2.0.0-wip
 description: >
   A shelf handler that wires up a listener for every connection.
 repository: https://github.com/dart-lang/shelf/tree/master/pkgs/shelf_web_socket
@@ -19,9 +19,4 @@ dependencies:
 dev_dependencies:
   dart_flutter_team_lints: ^2.0.0
   http: '>=0.13.0 <2.0.0'
-  test: ^1.16.0
-
-# Remove this when a version of `package:test` is released that is compatible
-# with self_web_socket 2.x
-dependency_overrides:
-  test: 1.25.2
+  test: ^1.25.2


### PR DESCRIPTION
- They are no longer needed now that `package:test` `1.25.2` is released.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
