### PR TITLE
`Headers.fromEntries`: using `CaseInsensitiveMap.fromEntries`

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -40,16 +40,16 @@ jobs:
       - name: mono_repo self validate
         run: dart pub global run mono_repo generate --validate
   job_002:
-    name: "analyze_and_format; linux; Dart 3.3.0; PKGS: pkgs/shelf, pkgs/shelf_packages_handler, pkgs/shelf_proxy, pkgs/shelf_router, pkgs/shelf_router_generator, pkgs/shelf_static, pkgs/shelf_test_handler, pkgs/shelf_web_socket; `dart analyze --fatal-infos .`"
+    name: "analyze_and_format; linux; Dart 3.3.0; PKGS: pkgs/shelf_packages_handler, pkgs/shelf_proxy, pkgs/shelf_router, pkgs/shelf_router_generator, pkgs/shelf_static, pkgs/shelf_test_handler, pkgs/shelf_web_socket; `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:pkgs/shelf-pkgs/shelf_packages_handler-pkgs/shelf_proxy-pkgs/shelf_router-pkgs/shelf_router_generator-pkgs/shelf_static-pkgs/shelf_test_handler-pkgs/shelf_web_socket;commands:analyze"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:pkgs/shelf_packages_handler-pkgs/shelf_proxy-pkgs/shelf_router-pkgs/shelf_router_generator-pkgs/shelf_static-pkgs/shelf_test_handler-pkgs/shelf_web_socket;commands:analyze"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:pkgs/shelf-pkgs/shelf_packages_handler-pkgs/shelf_proxy-pkgs/shelf_router-pkgs/shelf_router_generator-pkgs/shelf_static-pkgs/shelf_test_handler-pkgs/shelf_web_socket
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:pkgs/shelf_packages_handler-pkgs/shelf_proxy-pkgs/shelf_router-pkgs/shelf_router_generator-pkgs/shelf_static-pkgs/shelf_test_handler-pkgs/shelf_web_socket
             os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -60,15 +60,6 @@ jobs:
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
-      - id: pkgs_shelf_pub_upgrade
-        name: pkgs/shelf; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/shelf
-      - name: "pkgs/shelf; dart analyze --fatal-infos ."
-        run: dart analyze --fatal-infos .
-        if: "always() && steps.pkgs_shelf_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/shelf
       - id: pkgs_shelf_packages_handler_pub_upgrade
         name: pkgs/shelf_packages_handler; dart pub upgrade
         run: dart pub upgrade
@@ -133,6 +124,36 @@ jobs:
         if: "always() && steps.pkgs_shelf_web_socket_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/shelf_web_socket
   job_003:
+    name: "analyze_and_format; linux; Dart 3.4.0; PKG: pkgs/shelf; `dart analyze --fatal-infos .`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:pkgs/shelf;commands:analyze"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:pkgs/shelf
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
+        with:
+          sdk: "3.4.0"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
+      - id: pkgs_shelf_pub_upgrade
+        name: pkgs/shelf; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/shelf
+      - name: "pkgs/shelf; dart analyze --fatal-infos ."
+        run: dart analyze --fatal-infos .
+        if: "always() && steps.pkgs_shelf_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/shelf
+  job_004:
     name: "analyze_and_format; linux; Dart dev; PKGS: pkgs/shelf, pkgs/shelf_packages_handler, pkgs/shelf_proxy, pkgs/shelf_router, pkgs/shelf_router_generator, pkgs/shelf_static, pkgs/shelf_test_handler, pkgs/shelf_web_socket; `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
@@ -225,7 +246,7 @@ jobs:
         run: dart analyze --fatal-infos .
         if: "always() && steps.pkgs_shelf_web_socket_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/shelf_web_socket
-  job_004:
+  job_005:
     name: "analyze_and_format; linux; Dart dev; PKGS: pkgs/shelf, pkgs/shelf_packages_handler, pkgs/shelf_proxy, pkgs/shelf_router, pkgs/shelf_router_generator, pkgs/shelf_static, pkgs/shelf_test_handler, pkgs/shelf_web_socket; `dart format --output=none --set-exit-if-changed .`"
     runs-on: ubuntu-latest
     steps:
@@ -318,61 +339,17 @@ jobs:
         run: "dart format --output=none --set-exit-if-changed ."
         if: "always() && steps.pkgs_shelf_web_socket_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/shelf_web_socket
-  job_005:
-    name: "unit_test; linux; Dart 3.3.0; PKGS: pkgs/shelf, pkgs/shelf_test_handler; `dart test --test-randomize-ordering-seed=random -p chrome`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:pkgs/shelf-pkgs/shelf_test_handler;commands:test_1"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:pkgs/shelf-pkgs/shelf_test_handler
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
-        with:
-          sdk: "3.3.0"
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
-      - id: pkgs_shelf_pub_upgrade
-        name: pkgs/shelf; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/shelf
-      - name: "pkgs/shelf; dart test --test-randomize-ordering-seed=random -p chrome"
-        run: "dart test --test-randomize-ordering-seed=random -p chrome"
-        if: "always() && steps.pkgs_shelf_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/shelf
-      - id: pkgs_shelf_test_handler_pub_upgrade
-        name: pkgs/shelf_test_handler; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/shelf_test_handler
-      - name: "pkgs/shelf_test_handler; dart test --test-randomize-ordering-seed=random -p chrome"
-        run: "dart test --test-randomize-ordering-seed=random -p chrome"
-        if: "always() && steps.pkgs_shelf_test_handler_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/shelf_test_handler
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
   job_006:
-    name: "unit_test; linux; Dart 3.3.0; PKGS: pkgs/shelf, pkgs/shelf_packages_handler, pkgs/shelf_proxy, pkgs/shelf_router, pkgs/shelf_router_generator, pkgs/shelf_static, pkgs/shelf_test_handler, pkgs/shelf_web_socket; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.3.0; PKGS: pkgs/shelf_packages_handler, pkgs/shelf_proxy, pkgs/shelf_router, pkgs/shelf_router_generator, pkgs/shelf_static, pkgs/shelf_test_handler, pkgs/shelf_web_socket; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:pkgs/shelf-pkgs/shelf_packages_handler-pkgs/shelf_proxy-pkgs/shelf_router-pkgs/shelf_router_generator-pkgs/shelf_static-pkgs/shelf_test_handler-pkgs/shelf_web_socket;commands:test_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:pkgs/shelf_packages_handler-pkgs/shelf_proxy-pkgs/shelf_router-pkgs/shelf_router_generator-pkgs/shelf_static-pkgs/shelf_test_handler-pkgs/shelf_web_socket;commands:test_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:pkgs/shelf-pkgs/shelf_packages_handler-pkgs/shelf_proxy-pkgs/shelf_router-pkgs/shelf_router_generator-pkgs/shelf_static-pkgs/shelf_test_handler-pkgs/shelf_web_socket
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:pkgs/shelf_packages_handler-pkgs/shelf_proxy-pkgs/shelf_router-pkgs/shelf_router_generator-pkgs/shelf_static-pkgs/shelf_test_handler-pkgs/shelf_web_socket
             os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -383,15 +360,6 @@ jobs:
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
-      - id: pkgs_shelf_pub_upgrade
-        name: pkgs/shelf; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/shelf
-      - name: "pkgs/shelf; dart test --test-randomize-ordering-seed=random"
-        run: "dart test --test-randomize-ordering-seed=random"
-        if: "always() && steps.pkgs_shelf_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/shelf
       - id: pkgs_shelf_packages_handler_pub_upgrade
         name: pkgs/shelf_packages_handler; dart pub upgrade
         run: dart pub upgrade
@@ -460,7 +428,116 @@ jobs:
       - job_002
       - job_003
       - job_004
+      - job_005
   job_007:
+    name: "unit_test; linux; Dart 3.3.0; PKG: pkgs/shelf_test_handler; `dart test --test-randomize-ordering-seed=random -p chrome`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:pkgs/shelf_test_handler;commands:test_1"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:pkgs/shelf_test_handler
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
+        with:
+          sdk: "3.3.0"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
+      - id: pkgs_shelf_test_handler_pub_upgrade
+        name: pkgs/shelf_test_handler; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/shelf_test_handler
+      - name: "pkgs/shelf_test_handler; dart test --test-randomize-ordering-seed=random -p chrome"
+        run: "dart test --test-randomize-ordering-seed=random -p chrome"
+        if: "always() && steps.pkgs_shelf_test_handler_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/shelf_test_handler
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+  job_008:
+    name: "unit_test; linux; Dart 3.4.0; PKG: pkgs/shelf; `dart test --test-randomize-ordering-seed=random -p chrome`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:pkgs/shelf;commands:test_1"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:pkgs/shelf
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
+        with:
+          sdk: "3.4.0"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
+      - id: pkgs_shelf_pub_upgrade
+        name: pkgs/shelf; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/shelf
+      - name: "pkgs/shelf; dart test --test-randomize-ordering-seed=random -p chrome"
+        run: "dart test --test-randomize-ordering-seed=random -p chrome"
+        if: "always() && steps.pkgs_shelf_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/shelf
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+  job_009:
+    name: "unit_test; linux; Dart 3.4.0; PKG: pkgs/shelf; `dart test --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:pkgs/shelf;commands:test_0"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:pkgs/shelf
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
+        with:
+          sdk: "3.4.0"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
+      - id: pkgs_shelf_pub_upgrade
+        name: pkgs/shelf; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/shelf
+      - name: "pkgs/shelf; dart test --test-randomize-ordering-seed=random"
+        run: "dart test --test-randomize-ordering-seed=random"
+        if: "always() && steps.pkgs_shelf_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/shelf
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+  job_010:
     name: "unit_test; linux; Dart dev; PKGS: pkgs/shelf, pkgs/shelf_test_handler; `dart test --test-randomize-ordering-seed=random -p chrome -c dart2wasm`"
     runs-on: ubuntu-latest
     steps:
@@ -504,7 +581,8 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_008:
+      - job_005
+  job_011:
     name: "unit_test; linux; Dart dev; PKGS: pkgs/shelf, pkgs/shelf_test_handler; `dart test --test-randomize-ordering-seed=random -p chrome`"
     runs-on: ubuntu-latest
     steps:
@@ -548,7 +626,8 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_009:
+      - job_005
+  job_012:
     name: "unit_test; linux; Dart dev; PKGS: pkgs/shelf, pkgs/shelf_packages_handler, pkgs/shelf_proxy, pkgs/shelf_router, pkgs/shelf_router_generator, pkgs/shelf_static, pkgs/shelf_test_handler, pkgs/shelf_web_socket; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -646,7 +725,8 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_010:
+      - job_005
+  job_013:
     name: "unit_test; linux; Dart dev; PKG: pkgs/shelf_router_generator; `dart test --run-skipped -t presubmit-only`"
     runs-on: ubuntu-latest
     steps:
@@ -681,41 +761,8 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_011:
-    name: "unit_test; windows; Dart 3.3.0; PKGS: pkgs/shelf, pkgs/shelf_test_handler; `dart test --test-randomize-ordering-seed=random -p chrome`"
-    runs-on: windows-latest
-    steps:
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
-        with:
-          sdk: "3.3.0"
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
-      - id: pkgs_shelf_pub_upgrade
-        name: pkgs/shelf; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/shelf
-      - name: "pkgs/shelf; dart test --test-randomize-ordering-seed=random -p chrome"
-        run: "dart test --test-randomize-ordering-seed=random -p chrome"
-        if: "always() && steps.pkgs_shelf_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/shelf
-      - id: pkgs_shelf_test_handler_pub_upgrade
-        name: pkgs/shelf_test_handler; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/shelf_test_handler
-      - name: "pkgs/shelf_test_handler; dart test --test-randomize-ordering-seed=random -p chrome"
-        run: "dart test --test-randomize-ordering-seed=random -p chrome"
-        if: "always() && steps.pkgs_shelf_test_handler_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/shelf_test_handler
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-  job_012:
+      - job_005
+  job_014:
     name: "unit_test; windows; Dart 3.3.0; PKGS: pkgs/shelf_packages_handler, pkgs/shelf_static, pkgs/shelf_test_handler, pkgs/shelf_web_socket; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -767,7 +814,60 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_013:
+      - job_005
+  job_015:
+    name: "unit_test; windows; Dart 3.3.0; PKG: pkgs/shelf_test_handler; `dart test --test-randomize-ordering-seed=random -p chrome`"
+    runs-on: windows-latest
+    steps:
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
+        with:
+          sdk: "3.3.0"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
+      - id: pkgs_shelf_test_handler_pub_upgrade
+        name: pkgs/shelf_test_handler; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/shelf_test_handler
+      - name: "pkgs/shelf_test_handler; dart test --test-randomize-ordering-seed=random -p chrome"
+        run: "dart test --test-randomize-ordering-seed=random -p chrome"
+        if: "always() && steps.pkgs_shelf_test_handler_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/shelf_test_handler
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+  job_016:
+    name: "unit_test; windows; Dart 3.4.0; PKG: pkgs/shelf; `dart test --test-randomize-ordering-seed=random -p chrome`"
+    runs-on: windows-latest
+    steps:
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
+        with:
+          sdk: "3.4.0"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
+      - id: pkgs_shelf_pub_upgrade
+        name: pkgs/shelf; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/shelf
+      - name: "pkgs/shelf; dart test --test-randomize-ordering-seed=random -p chrome"
+        run: "dart test --test-randomize-ordering-seed=random -p chrome"
+        if: "always() && steps.pkgs_shelf_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/shelf
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+  job_017:
     name: "unit_test; windows; Dart dev; PKGS: pkgs/shelf, pkgs/shelf_test_handler; `dart test --test-randomize-ordering-seed=random -p chrome`"
     runs-on: windows-latest
     steps:
@@ -801,7 +901,8 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_014:
+      - job_005
+  job_018:
     name: "unit_test; windows; Dart dev; PKGS: pkgs/shelf_packages_handler, pkgs/shelf_static, pkgs/shelf_test_handler, pkgs/shelf_web_socket; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -853,3 +954,4 @@ jobs:
       - job_002
       - job_003
       - job_004
+      - job_005

--- a/pkgs/shelf/CHANGELOG.md
+++ b/pkgs/shelf/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * `Headers`: added the `fromEntries`  constructor.
 * Require `http_parser`: ^4.1.0
-* Require Dart `^3.3.0`.
+* Require Dart `^3.4.0`.
 
 ## 1.4.1
 

--- a/pkgs/shelf/CHANGELOG.md
+++ b/pkgs/shelf/CHANGELOG.md
@@ -1,12 +1,8 @@
-## 1.4.2-wip
+## 1.4.2
 
-* `Headers`:
-  * Added the constructor `Headers.fromEntries`.
-  * Added the internal constructor `_fromEntries`, which uses `CaseInsensitiveMap.fromEntries` for optimization.
-  * Renamed the internal constructor `_` to `_from`, redirecting it to `this._fromEntries`.
-
+* `Headers`: added the `fromEntries`  constructor.
+* Require `http_parser`: ^4.1.0
 * Require Dart `^3.3.0`.
-* http_parser: ^4.1.0
 
 ## 1.4.1
 

--- a/pkgs/shelf/CHANGELOG.md
+++ b/pkgs/shelf/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.4.2-wip
 
+* `Headers`:
+  * Optimize constructor `_`: use `CaseInsensitiveMap.fromEntries`.
+
 * Require Dart `^3.3.0`.
 
 ## 1.4.1

--- a/pkgs/shelf/CHANGELOG.md
+++ b/pkgs/shelf/CHANGELOG.md
@@ -6,6 +6,7 @@
   * Renamed the internal constructor `_` to `_from`, redirecting it to `this._fromEntries`.
 
 * Require Dart `^3.3.0`.
+* http_parser: ^4.1.0
 
 ## 1.4.1
 

--- a/pkgs/shelf/CHANGELOG.md
+++ b/pkgs/shelf/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## 1.4.2-wip
 
 * `Headers`:
-  * Optimize constructor `_`: use `CaseInsensitiveMap.fromEntries`.
+  * Added the constructor `Headers.fromEntries`.
+  * Added the internal constructor `_fromEntries`, which uses `CaseInsensitiveMap.fromEntries` for optimization.
+  * Renamed the internal constructor `_` to `_from`, redirecting it to `this._fromEntries`.
 
 * Require Dart `^3.3.0`.
 

--- a/pkgs/shelf/lib/src/headers.dart
+++ b/pkgs/shelf/lib/src/headers.dart
@@ -24,7 +24,7 @@ class Headers extends UnmodifiableMapView<String, List<String>> {
     } else if (values is Headers) {
       return values;
     } else {
-      return Headers._fromEntries(values.entries);
+      return Headers._(values.entries);
     }
   }
 
@@ -33,11 +33,11 @@ class Headers extends UnmodifiableMapView<String, List<String>> {
     if (values == null || (values is List && values.isEmpty)) {
       return _emptyHeaders;
     } else {
-      return Headers._fromEntries(values);
+      return Headers._(values);
     }
   }
 
-  Headers._fromEntries(Iterable<MapEntry<String, List<String>>> entries)
+  Headers._(Iterable<MapEntry<String, List<String>>> entries)
       : super(CaseInsensitiveMap.fromEntries(entries
             .where((e) => e.value.isNotEmpty)
             .map((e) => MapEntry(e.key, List.unmodifiable(e.value)))));

--- a/pkgs/shelf/lib/src/headers.dart
+++ b/pkgs/shelf/lib/src/headers.dart
@@ -29,9 +29,9 @@ class Headers extends UnmodifiableMapView<String, List<String>> {
   }
 
   Headers._(Map<String, List<String>> values)
-      : super(CaseInsensitiveMap.from(Map.fromEntries(values.entries
+      : super(CaseInsensitiveMap.fromEntries(values.entries
             .where((e) => e.value.isNotEmpty)
-            .map((e) => MapEntry(e.key, List.unmodifiable(e.value))))));
+            .map((e) => MapEntry(e.key, List.unmodifiable(e.value)))));
 
   Headers._empty() : super(const {});
 

--- a/pkgs/shelf/lib/src/headers.dart
+++ b/pkgs/shelf/lib/src/headers.dart
@@ -24,7 +24,7 @@ class Headers extends UnmodifiableMapView<String, List<String>> {
     } else if (values is Headers) {
       return values;
     } else {
-      return Headers._from(values);
+      return Headers._fromEntries(values.entries);
     }
   }
 
@@ -36,9 +36,6 @@ class Headers extends UnmodifiableMapView<String, List<String>> {
       return Headers._fromEntries(values);
     }
   }
-
-  Headers._from(Map<String, List<String>> values)
-      : this._fromEntries(values.entries);
 
   Headers._fromEntries(Iterable<MapEntry<String, List<String>>> entries)
       : super(CaseInsensitiveMap.fromEntries(entries

--- a/pkgs/shelf/lib/src/headers.dart
+++ b/pkgs/shelf/lib/src/headers.dart
@@ -29,18 +29,23 @@ class Headers extends UnmodifiableMapView<String, List<String>> {
   }
 
   factory Headers.fromEntries(
-      Iterable<MapEntry<String, List<String>>>? values) {
-    if (values == null || (values is List && values.isEmpty)) {
+    Iterable<MapEntry<String, List<String>>>? entries,
+  ) {
+    if (entries == null || (entries is List && entries.isEmpty)) {
       return _emptyHeaders;
     } else {
-      return Headers._(values);
+      return Headers._(entries);
     }
   }
 
   Headers._(Iterable<MapEntry<String, List<String>>> entries)
-      : super(CaseInsensitiveMap.fromEntries(entries
-            .where((e) => e.value.isNotEmpty)
-            .map((e) => MapEntry(e.key, List.unmodifiable(e.value)))));
+      : super(
+          CaseInsensitiveMap.fromEntries(
+            entries
+                .where((e) => e.value.isNotEmpty)
+                .map((e) => MapEntry(e.key, List.unmodifiable(e.value))),
+          ),
+        );
 
   Headers._empty() : super(const {});
 

--- a/pkgs/shelf/lib/src/headers.dart
+++ b/pkgs/shelf/lib/src/headers.dart
@@ -24,12 +24,24 @@ class Headers extends UnmodifiableMapView<String, List<String>> {
     } else if (values is Headers) {
       return values;
     } else {
-      return Headers._(values);
+      return Headers._from(values);
     }
   }
 
-  Headers._(Map<String, List<String>> values)
-      : super(CaseInsensitiveMap.fromEntries(values.entries
+  factory Headers.fromEntries(
+      Iterable<MapEntry<String, List<String>>>? values) {
+    if (values == null || (values is List && values.isEmpty)) {
+      return _emptyHeaders;
+    } else {
+      return Headers._fromEntries(values);
+    }
+  }
+
+  Headers._from(Map<String, List<String>> values)
+      : this._fromEntries(values.entries);
+
+  Headers._fromEntries(Iterable<MapEntry<String, List<String>>> entries)
+      : super(CaseInsensitiveMap.fromEntries(entries
             .where((e) => e.value.isNotEmpty)
             .map((e) => MapEntry(e.key, List.unmodifiable(e.value)))));
 

--- a/pkgs/shelf/pubspec.yaml
+++ b/pkgs/shelf/pubspec.yaml
@@ -15,7 +15,7 @@ environment:
 dependencies:
   async: ^2.5.0
   collection: ^1.15.0
-  http_parser: ^4.0.0
+  http_parser: ^4.1.0
   path: ^1.8.0
   stack_trace: ^1.10.0
   stream_channel: ^2.1.0

--- a/pkgs/shelf/pubspec.yaml
+++ b/pkgs/shelf/pubspec.yaml
@@ -10,7 +10,7 @@ topics:
   - backend
 
 environment:
-  sdk: ^3.3.0
+  sdk: ^3.4.0
 
 dependencies:
   async: ^2.5.0

--- a/pkgs/shelf/pubspec.yaml
+++ b/pkgs/shelf/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf
-version: 1.4.2-wip
+version: 1.4.2
 description: >
   A model for web server middleware that encourages composition and easy reuse.
 repository: https://github.com/dart-lang/shelf/tree/master/pkgs/shelf

--- a/pkgs/shelf/test/headers_test.dart
+++ b/pkgs/shelf/test/headers_test.dart
@@ -1,0 +1,28 @@
+import 'package:shelf/src/headers.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('Headers.from', () {
+    var header = Headers.from({
+      'FoO': ['x', 'y'],
+      'bAr': ['z'],
+    });
+
+    expect(header['foo'], equals(['x', 'y']));
+    expect(header['BAR'], equals(['z']));
+
+    expect(() => header['X'] = ['x'], throwsA(isA<UnsupportedError>()));
+  });
+
+  test('Headers.fromEntries', () {
+    var header = Headers.fromEntries({
+      'FoO': ['x', 'y'],
+      'bAr': ['z'],
+    }.entries);
+
+    expect(header['foo'], equals(['x', 'y']));
+    expect(header['BAR'], equals(['z']));
+
+    expect(() => header['X'] = ['x'], throwsA(isA<UnsupportedError>()));
+  });
+}


### PR DESCRIPTION
* `Headers`:
  * Added the constructor `Headers.fromEntries`.
  * Added the internal constructor `_fromEntries`, which uses `CaseInsensitiveMap.fromEntries` for optimization.
  * Renamed the internal constructor `_` to `_from`, redirecting it to `this._fromEntries`.

---

- [✅ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
