### PR TITLE
loosen mime package constraint

### DIFF
--- a/pkgs/shelf_static/CHANGELOG.md
+++ b/pkgs/shelf_static/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.1.3-wip
 
 * Require Dart `^3.3.0`.
+* Update `package:mime` constraint to `>=1.0.0 <3.0.0`. 
 
 ## 1.1.2
 

--- a/pkgs/shelf_static/pubspec.yaml
+++ b/pkgs/shelf_static/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 dependencies:
   convert: ^3.0.0
   http_parser: ^4.0.0
-  mime: ^1.0.0
+  mime: '>=1.0.0 <3.0.0'
   path: ^1.8.0
   # shelf version that allows correctly setting content-length w/ HEAD
   shelf: ^1.1.2


### PR DESCRIPTION
A breaking change is about to be released for the mime package: the return value of `extensionFromMime` function has become nullable. If there is no extension found for the mime type, `null` is now returned instead of the mimeType being passed. Or in code:

```
/// Returns the extension for the given MIME type.
///
/// If there are multiple extensions for [mime], return the first occurrence in
/// the map. If there are no extensions for [mime], return [mime].
String extensionFromMime(String mime) 
```
became


```
/// The default file extension for a given MIME type.
///
/// If [mimeType] has multiple associated extensions,
/// the returned string is one of those, chosen as the default
/// extension for that MIME type.
///
/// Returns `null` if [mimeType] is not a recognized and
/// supported MIME type.
String? extensionFromMime(String mimeType)
```

see https://github.com/dart-lang/tools/pull/431#issuecomment-2321797361 for more info.

Since I did not find any usages of this method in this package, we believe it's safe to loosen the constraint here.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
