### PR TITLE
Remove links to core types with generics

### DIFF
--- a/pkgs/shelf/CHANGELOG.md
+++ b/pkgs/shelf/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.4.3-wip
+
 ## 1.4.2
 
 * `Headers`: added the `fromEntries`  constructor.

--- a/pkgs/shelf/lib/shelf_io.dart
+++ b/pkgs/shelf/lib/shelf_io.dart
@@ -74,7 +74,7 @@ Future<HttpServer> serve(
 
 /// Serve a [Stream] of [HttpRequest]s.
 ///
-/// [HttpServer] implements [Stream<HttpRequest>] so it can be passed directly
+/// [HttpServer] implements `Stream<HttpRequest>` so it can be passed directly
 /// to [serveRequests].
 ///
 /// Errors thrown by [handler] while serving a request will be printed to the

--- a/pkgs/shelf/lib/src/body.dart
+++ b/pkgs/shelf/lib/src/body.dart
@@ -28,9 +28,9 @@ class Body {
 
   /// Converts [body] to a byte stream and wraps it in a [Body].
   ///
-  /// [body] may be either a [Body], a [String], a [List<int>], a
-  /// [Stream<List<int>>], or `null`. If it's a [String], [encoding] will be
-  /// used to convert it to a [Stream<List<int>>].
+  /// [body] may be either a [Body], a [String], a `List<int>`, a
+  /// `Stream<List<int>>`, or `null`. If it's a [String], [encoding] will be
+  /// used to convert it to a `Stream<List<int>>`.
   factory Body(Object? body, [Encoding? encoding]) {
     if (body is Body) return body;
 

--- a/pkgs/shelf/lib/src/message.dart
+++ b/pkgs/shelf/lib/src/message.dart
@@ -67,9 +67,9 @@ abstract class Message {
 
   /// Creates a new [Message].
   ///
-  /// [body] is the response body. It may be either a [String], a [List<int>], a
-  /// [Stream<List<int>>], or `null` to indicate no body. If it's a [String],
-  /// [encoding] is used to encode it to a [Stream<List<int>>]. It defaults to
+  /// [body] is the response body. It may be either a [String], a `List<int>`, a
+  /// `Stream<List<int>>`, or `null` to indicate no body. If it's a [String],
+  /// [encoding] is used to encode it to a `Stream<List<int>>`. It defaults to
   /// UTF-8.
   ///
   /// If [headers] is `null`, it is treated as empty.

--- a/pkgs/shelf/lib/src/middleware.dart
+++ b/pkgs/shelf/lib/src/middleware.dart
@@ -30,7 +30,7 @@ typedef Middleware = Handler Function(Handler innerHandler);
 /// Creates a [Middleware] using the provided functions.
 ///
 /// If provided, [requestHandler] receives a [Request]. It can respond to
-/// the request by returning a [Response] or [Future<Response>].
+/// the request by returning a [Response] or `Future<Response>`.
 /// [requestHandler] can also return `null` for some or all requests in which
 /// case the request is sent to the inner [Handler].
 ///
@@ -39,7 +39,7 @@ typedef Middleware = Handler Function(Handler innerHandler);
 /// sent to [responseHandler].
 ///
 /// [responseHandler] should return either a [Response] or
-/// [Future<Response>]. It may return the response parameter it receives or
+/// `Future<Response>`. It may return the response parameter it receives or
 /// create a new response object.
 ///
 /// If provided, [errorHandler] receives errors thrown by the inner handler. It

--- a/pkgs/shelf/lib/src/request.dart
+++ b/pkgs/shelf/lib/src/request.dart
@@ -89,9 +89,9 @@ class Request extends Message {
   /// and [url] to `requestedUri.path` without the initial `/`. If only one is
   /// passed, the other will be inferred.
   ///
-  /// [body] is the request body. It may be either a [String], a [List<int>], a
-  /// [Stream<List<int>>], or `null` to indicate no body. If it's a [String],
-  /// [encoding] is used to encode it to a [Stream<List<int>>]. The default
+  /// [body] is the request body. It may be either a [String], a `List<int>`, a
+  /// `Stream<List<int>>`, or `null` to indicate no body. If it's a [String],
+  /// [encoding] is used to encode it to a `Stream<List<int>>`. The default
   /// encoding is UTF-8.
   ///
   /// If [encoding] is passed, the "encoding" field of the Content-Type header
@@ -225,8 +225,8 @@ class Request extends Message {
   /// All other context and header values from the [Request] will be
   /// included in the copied [Request] unchanged.
   ///
-  /// [body] is the request body. It may be either a [String], a [List<int>], a
-  /// [Stream<List<int>>], or `null` to indicate no body.
+  /// [body] is the request body. It may be either a [String], a `List<int>`, a
+  /// `Stream<List<int>>`, or `null` to indicate no body.
   ///
   /// [path] is used to update both [handlerPath] and [url]. It's designed for
   /// routing middleware, and represents the path from the current handler to
@@ -268,7 +268,7 @@ class Request extends Message {
   ///
   /// Synchronously, this throws a [HijackException] that indicates to the
   /// adapter that it shouldn't emit a response itself. Asynchronously,
-  /// [callback] is called with a [StreamChannel<List<int>>] that provides
+  /// [callback] is called with a `StreamChannel<List<int>>` that provides
   /// access to the underlying request socket.
   ///
   /// This may only be called when using a Shelf adapter that supports

--- a/pkgs/shelf/lib/src/response.dart
+++ b/pkgs/shelf/lib/src/response.dart
@@ -46,14 +46,14 @@ class Response extends Message {
   /// This indicates that the request has succeeded.
   ///
   /// {@template shelf_response_body_and_encoding_param}
-  /// [body] is the response body. It may be either a [String], a [List<int>], a
-  /// [Stream<List<int>>], or `null` to indicate no body.
+  /// [body] is the response body. It may be either a [String], a `List<int>`, a
+  /// `Stream<List<int>>`, or `null` to indicate no body.
   ///
   /// If the body is a [String], [encoding] is used to encode it to a
-  /// [Stream<List<int>>]. It defaults to UTF-8. If it's a [String], a
-  /// [List<int>], or `null`, the Content-Length header is set automatically
+  /// `Stream<List<int>>`. It defaults to UTF-8. If it's a [String], a
+  /// `List<int>`, or `null`, the Content-Length header is set automatically
   /// unless a Transfer-Encoding header is set. Otherwise, it's a
-  /// [Stream<List<int>>] and no Transfer-Encoding header is set, the adapter
+  /// `Stream<List<int>>` and no Transfer-Encoding header is set, the adapter
   /// will set the Transfer-Encoding header to "chunked" and apply the chunked
   /// encoding to the body.
   ///
@@ -289,8 +289,8 @@ class Response extends Message {
   /// All other context and header values from the [Response] will be included
   /// in the copied [Response] unchanged.
   ///
-  /// [body] is the response body. It may be either a [String], a [List<int>], a
-  /// [Stream<List<int>>], or `<int>[]` (empty list) to indicate no body.
+  /// [body] is the response body. It may be either a [String], a `List<int>`, a
+  /// `Stream<List<int>>`, or `<int>[]` (empty list) to indicate no body.
   @override
   Response change({
     Map<String, /* String | List<String> */ Object?>? headers,

--- a/pkgs/shelf/pubspec.yaml
+++ b/pkgs/shelf/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf
-version: 1.4.2
+version: 1.4.3-wip
 description: >
   A model for web server middleware that encourages composition and easy reuse.
 repository: https://github.com/dart-lang/shelf/tree/master/pkgs/shelf


### PR DESCRIPTION
Work around a false positive in the lint unintended_html_in_doc_comment.

It is not necessary to link to core collection types or `Stream`
repeatedly in our docs.
