### PR TITLE
Add getParams method to router.dart

### DIFF
--- a/pkgs/shelf_router/lib/src/router.dart
+++ b/pkgs/shelf_router/lib/src/router.dart
@@ -190,6 +190,21 @@ class Router {
     return _notFoundHandler(request);
   }
 
+  /// Get URL parameters captured by the [Router].
+  /// Returns `null` if no parameters are captured.
+  Map<String, String>? getParams(Request request) {
+    for (var route in _routes) {
+      if (route.verb != request.method.toUpperCase() && route.verb != 'ALL') {
+        continue;
+      }
+      var params = route.match('/${request.url.path}');
+      if (params != null) {
+        return params;
+      }
+    }
+    return null;
+  }
+
   // Handlers for all methods
 
   /// Handle `GET` request to [route] using [handler].


### PR DESCRIPTION
This PR adds a `getParams` method to the handler. This allows to extract the params of a URI from a request without actually handling the request in a middleware.

As far as I am aware, this was not possible in any other way before, as the `routes` are private in a `Router`.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
