### PR TITLE
move analysis_options.yaml into packages

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,4 +1,4 @@
-# Created with package:mono_repo v6.6.1
+# Created with package:mono_repo v6.6.2
 name: Dart CI
 on:
   push:
@@ -36,7 +36,7 @@ jobs:
         name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: mono_repo self validate
-        run: dart pub global activate mono_repo 6.6.1
+        run: dart pub global activate mono_repo 6.6.2
       - name: mono_repo self validate
         run: dart pub global run mono_repo generate --validate
   job_002:

--- a/pkgs/shelf/CHANGELOG.md
+++ b/pkgs/shelf/CHANGELOG.md
@@ -280,7 +280,7 @@
 
 ## 0.6.1+2
 
-* `logRequests` outputs a better message a request has a query string.
+* `logRequests` outputs a better message if a request has a query string.
 
 ## 0.6.1+1
 

--- a/pkgs/shelf/analysis_options.yaml
+++ b/pkgs/shelf/analysis_options.yaml
@@ -1,13 +1,10 @@
 # https://dart.dev/guides/language/analysis-options
+
 include: package:dart_flutter_team_lints/analysis_options.yaml
 
 analyzer:
   language:
-    strict-casts: true
-    strict-inference: true
     strict-raw-types: true
-  errors:
-    comment_references: ignore # too many false positives
 
 linter:
   rules:
@@ -17,5 +14,4 @@ linter:
     - missing_whitespace_between_adjacent_strings
     - no_adjacent_strings_in_list
     - no_runtimeType_toString
-    - package_api_docs
     - unnecessary_await_in_return

--- a/pkgs/shelf/lib/src/body.dart
+++ b/pkgs/shelf/lib/src/body.dart
@@ -5,6 +5,8 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'message.dart';
+
 /// The body of a request or response.
 ///
 /// This tracks whether the body has been read. It's separate from [Message]

--- a/pkgs/shelf/lib/src/hijack_exception.dart
+++ b/pkgs/shelf/lib/src/hijack_exception.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'request.dart';
+
 /// An exception used to indicate that a request has been hijacked.
 ///
 /// This shouldn't be captured by any code other than the Shelf adapter that

--- a/pkgs/shelf/lib/src/message.dart
+++ b/pkgs/shelf/lib/src/message.dart
@@ -10,6 +10,9 @@ import 'package:http_parser/http_parser.dart';
 
 import 'body.dart';
 import 'headers.dart';
+import 'middleware/logger.dart';
+import 'request.dart';
+import 'response.dart';
 import 'shelf_unmodifiable_map.dart';
 import 'util.dart';
 
@@ -171,7 +174,7 @@ abstract class Message {
       {Map<String, String> headers, Map<String, Object> context, Object? body});
 }
 
-/// Adds information about [encoding] to [headers].
+/// Adds information about encoding to [headers].
 ///
 /// Returns a new map without modifying [headers].
 Map<String, List<String>> _adjustHeaders(

--- a/pkgs/shelf/lib/src/middleware_extensions.dart
+++ b/pkgs/shelf/lib/src/middleware_extensions.dart
@@ -1,5 +1,6 @@
 import 'handler.dart';
 import 'middleware.dart';
+import 'pipeline.dart';
 
 /// Extensions on [Middleware] to aid in composing [Middleware] and [Handler]s.
 ///

--- a/pkgs/shelf/lib/src/pipeline.dart
+++ b/pkgs/shelf/lib/src/pipeline.dart
@@ -4,6 +4,7 @@
 
 import 'handler.dart';
 import 'middleware.dart';
+import 'request.dart';
 
 /// A helper that makes it easy to compose a set of [Middleware] and a
 /// [Handler].

--- a/pkgs/shelf/lib/src/response.dart
+++ b/pkgs/shelf/lib/src/response.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 
 import 'package:http_parser/http_parser.dart';
 
+import 'handler.dart';
 import 'message.dart';
 import 'util.dart';
 

--- a/pkgs/shelf/lib/src/server.dart
+++ b/pkgs/shelf/lib/src/server.dart
@@ -20,8 +20,8 @@ import 'handler.dart';
 /// code to a single server implementation.
 ///
 /// There are two built-in implementations of this interface. You can create a
-/// server backed by `dart:io` using [IOServer], or you can create a server
-/// that's backed by a normal [Handler] using [ServerHandler].
+/// server backed by `dart:io` using `IOServer`, or you can create a server
+/// that's backed by a normal [Handler] using `ServerHandler`.
 ///
 /// Implementations of this interface are responsible for ensuring that the
 /// members work as documented.

--- a/pkgs/shelf_packages_handler/analysis_options.yaml
+++ b/pkgs/shelf_packages_handler/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:dart_flutter_team_lints/analysis_options.yaml

--- a/pkgs/shelf_proxy/analysis_options.yaml
+++ b/pkgs/shelf_proxy/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:dart_flutter_team_lints/analysis_options.yaml

--- a/pkgs/shelf_router/analysis_options.yaml
+++ b/pkgs/shelf_router/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:dart_flutter_team_lints/analysis_options.yaml

--- a/pkgs/shelf_router_generator/analysis_options.yaml
+++ b/pkgs/shelf_router_generator/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:dart_flutter_team_lints/analysis_options.yaml

--- a/pkgs/shelf_static/analysis_options.yaml
+++ b/pkgs/shelf_static/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:dart_flutter_team_lints/analysis_options.yaml

--- a/pkgs/shelf_test_handler/analysis_options.yaml
+++ b/pkgs/shelf_test_handler/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:dart_flutter_team_lints/analysis_options.yaml

--- a/pkgs/shelf_test_handler/lib/src/expectation.dart
+++ b/pkgs/shelf_test_handler/lib/src/expectation.dart
@@ -4,6 +4,8 @@
 
 import 'package:shelf/shelf.dart';
 
+import 'handler.dart';
+
 /// A single expectation for an HTTP request sent to a [ShelfTestHandler].
 class Expectation {
   /// The expected request method, or `null` if this allows any requests.

--- a/pkgs/shelf_test_handler/lib/src/server.dart
+++ b/pkgs/shelf_test_handler/lib/src/server.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 
 import 'package:http_multi_server/http_multi_server.dart';
 import 'package:shelf/shelf_io.dart';
+import 'package:test/test.dart';
 
 import 'handler.dart';
 

--- a/pkgs/shelf_web_socket/analysis_options.yaml
+++ b/pkgs/shelf_web_socket/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:dart_flutter_team_lints/analysis_options.yaml

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Created with package:mono_repo v6.6.1
+# Created with package:mono_repo v6.6.2
 
 # Support built in commands on windows out of the box.
 


### PR DESCRIPTION
- move analysis_options.yaml into packages
- regenerate mono_repo files

This catches a number of diagnostics in the shelf packages (mostly instances of `comment_references` diagnostics).

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
