### PR TITLE
shelf_router_generator: bump dependencies

### DIFF
--- a/pkgs/shelf_router_generator/CHANGELOG.md
+++ b/pkgs/shelf_router_generator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.1.1-wip
 
+* Support the latest `package:analyzer` and `package:source_gen`
 * Require `sdk: ^3.3.0`
 
 ## 1.1.0

--- a/pkgs/shelf_router_generator/pubspec.yaml
+++ b/pkgs/shelf_router_generator/pubspec.yaml
@@ -14,18 +14,18 @@ environment:
   sdk: ^3.3.0
 
 dependencies:
-  analyzer: '>=4.6.0 <7.0.0'
-  build: ^2.0.0
+  analyzer: '>=4.6.0 <8.0.0'
+  build: ^2.2.2
   build_config: ^1.0.0
   code_builder: ^4.2.0
-  http_methods: ^1.0.0
+  http_methods: ^1.1.0
   shelf: ^1.1.0
   shelf_router: ^1.1.0
-  source_gen: ^1.0.0
+  source_gen: ">=1.2.2 <3.0.0"
 
 dev_dependencies:
-  build_runner: ^2.0.0
+  build_runner: ^2.1.9
   build_verify: ^3.0.0
   dart_flutter_team_lints: ^3.0.0
-  http: '>=0.13.0 <2.0.0'
-  test: ^1.5.3
+  http: ^1.0.0
+  test: ^1.21.0


### PR DESCRIPTION
The min versions bumps were updated using
` _PUB_TEST_SDK_VERSION=3.3.0 dart pub downgrade  --tighten`
