### PR TITLE
Publish shelf_router_generator 1.1.1

### DIFF
--- a/pkgs/shelf_router_generator/CHANGELOG.md
+++ b/pkgs/shelf_router_generator/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.1-wip
+## 1.1.1
 
 * Support the latest `package:analyzer` and `package:source_gen`
 * Require `sdk: ^3.3.0`

--- a/pkgs/shelf_router_generator/pubspec.yaml
+++ b/pkgs/shelf_router_generator/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf_router_generator
-version: 1.1.1-wip
+version: 1.1.1
 description: >
   A package:build-compatible builder for generating request routers for the
   shelf web-framework based on source annotations.


### PR DESCRIPTION
I think it's OK to publish this version now.

cc/ @devoncarew @kevmoo 