### PR TITLE
rev shelf_web_socket to 3.0 in prep for publishing

### DIFF
--- a/pkgs/shelf_web_socket/CHANGELOG.md
+++ b/pkgs/shelf_web_socket/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.0.0-wip
+## 3.0.0
 
 * **BREAKING:**: Change the signature of the `webSocketHandler` method's
   `onConnection` callback. Previously this took an untyped function with either

--- a/pkgs/shelf_web_socket/pubspec.yaml
+++ b/pkgs/shelf_web_socket/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf_web_socket
-version: 3.0.0-wip
+version: 3.0.0
 description: A shelf handler that wires up a listener for every connection.
 repository: https://github.com/dart-lang/shelf/tree/master/pkgs/shelf_web_socket
 issue_tracker: https://github.com/dart-lang/shelf/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Ashelf_web_socket


### PR DESCRIPTION
- rev shelf_web_socket to 3.0 in prep for publishing
- fix https://github.com/dart-lang/shelf/issues/457

Our various mono-repos (the sdk, google3, and flutter) have been preped for this change.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
