### PR TITLE
shelf_router: HEAD: do NOT change content-length

### DIFF
--- a/pkgs/shelf_router/CHANGELOG.md
+++ b/pkgs/shelf_router/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.1.5-wip
 
+* Fixed automatic `HEAD` request handling to not modify content-length.
 * Require Dart `^3.3.0`.
 
 ## 1.1.4

--- a/pkgs/shelf_router/lib/src/router.dart
+++ b/pkgs/shelf_router/lib/src/router.dart
@@ -58,13 +58,16 @@ extension RouterParams on Request {
   }
 }
 
-/// Middleware to remove body from request.
-final _removeBody = createMiddleware(responseHandler: (r) {
-  if (r.headers.containsKey('content-length')) {
-    r = r.change(headers: {'content-length': '0'});
-  }
-  return r.change(body: <int>[]);
-});
+/// Middleware to remove body from response for HEAD requests.
+Handler _removeBody(Handler handler) => (request) {
+      Response processResponse(Response r) => r.change(body: const <int>[]);
+
+      final response = handler(request);
+      if (response is Future<Response>) {
+        return response.then(processResponse);
+      }
+      return processResponse(response);
+    };
 
 /// A shelf [Router] routes requests to handlers based on HTTP verb and route
 /// pattern.

--- a/pkgs/shelf_router/test/router_test.dart
+++ b/pkgs/shelf_router/test/router_test.dart
@@ -40,8 +40,8 @@ void main() {
 
   Future<String> get(String path) =>
       http.read(Uri.parse(server.url.toString() + path));
-  Future<int> head(String path) async =>
-      (await http.head(Uri.parse(server.url.toString() + path))).statusCode;
+  Future<http.Response> head(String path) =>
+      http.head(Uri.parse(server.url.toString() + path));
 
   test('get sync/async handler', () async {
     var app = Router();
@@ -67,9 +67,20 @@ void main() {
     expect(await get('/async-hello'), 'hello-world');
     expect(await get('/wrong-path'), 'not-found');
 
-    expect(await head('/sync-hello'), 200);
-    expect(await head('/async-hello'), 200);
-    expect(await head('/wrong-path'), 200);
+    final syncHead = await head('/sync-hello');
+    expect(syncHead.statusCode, 200);
+    expect(syncHead.body, isEmpty);
+    expect(syncHead.headers['content-length'], '11');
+
+    final asyncHead = await head('/async-hello');
+    expect(asyncHead.statusCode, 200);
+    expect(asyncHead.body, isEmpty);
+    expect(asyncHead.headers['content-length'], '11');
+
+    final wrongPathHead = await head('/wrong-path');
+    expect(wrongPathHead.statusCode, 200);
+    expect(wrongPathHead.body, isEmpty);
+    expect(wrongPathHead.headers['content-length'], '9');
   });
 
   test('params', () async {

--- a/pkgs/shelf_router/test/router_test.dart
+++ b/pkgs/shelf_router/test/router_test.dart
@@ -38,10 +38,9 @@ void main() {
 
   tearDown(() => server.close());
 
-  Future<String> get(String path) =>
-      http.read(Uri.parse(server.url.toString() + path));
+  Future<String> get(String path) => http.read(server.url.resolve(path));
   Future<http.Response> head(String path) =>
-      http.head(Uri.parse(server.url.toString() + path));
+      http.head(server.url.resolve(path));
 
   test('get sync/async handler', () async {
     var app = Router();

--- a/pkgs/shelf_static/CHANGELOG.md
+++ b/pkgs/shelf_static/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add `generateETag` and `maxAge` parameters to `createStaticHandler` and
   `createFileHandler` to support `ETag` and `Cache-Control` headers. 
   Default ETags are generated based on file size and modified time.
+* Fixed automatic `HEAD` request handling to not modify content-length.
 
 ## 1.1.3
 

--- a/pkgs/shelf_static/CHANGELOG.md
+++ b/pkgs/shelf_static/CHANGELOG.md
@@ -7,7 +7,6 @@
 * Add `generateETag` and `maxAge` parameters to `createStaticHandler` and
   `createFileHandler` to support `ETag` and `Cache-Control` headers. 
   Default ETags are generated based on file size and modified time.
-* Fixed automatic `HEAD` request handling to not modify content-length.
 
 ## 1.1.3
 


### PR DESCRIPTION
Fixes https://github.com/dart-lang/shelf/issues/510

Also optimizes the implementation of _removeBody
