### PR TITLE
refactor: avoid http_methods dependency

### DIFF
--- a/pkgs/shelf_router/lib/src/router.dart
+++ b/pkgs/shelf_router/lib/src/router.dart
@@ -15,11 +15,28 @@
 import 'dart:collection' show UnmodifiableMapView;
 import 'dart:convert';
 
-import 'package:http_methods/http_methods.dart';
 import 'package:meta/meta.dart' show sealed;
 import 'package:shelf/shelf.dart';
 
 import 'trie.dart';
+
+/// Returns true if [method] is a valid HTTP method.
+bool isHttpMethod(String method) {
+  switch (method.toUpperCase()) {
+    case 'GET':
+    case 'HEAD':
+    case 'POST':
+    case 'PUT':
+    case 'DELETE':
+    case 'CONNECT':
+    case 'OPTIONS':
+    case 'TRACE':
+    case 'PATCH':
+      return true;
+    default:
+      return false;
+  }
+}
 
 /// Get a URL parameter captured by the [Router].
 @Deprecated('Use Request.params instead')

--- a/pkgs/shelf_router/pubspec.yaml
+++ b/pkgs/shelf_router/pubspec.yaml
@@ -14,7 +14,6 @@ environment:
   sdk: ^3.3.0
 
 dependencies:
-  http_methods: ^1.1.0
   meta: ^1.3.0
   shelf: ^1.0.0
 

--- a/pkgs/shelf_router_generator/lib/src/shelf_router_generator.dart
+++ b/pkgs/shelf_router_generator/lib/src/shelf_router_generator.dart
@@ -22,12 +22,29 @@ import 'package:analyzer/dart/element/element.dart'
 import 'package:analyzer/dart/element/type.dart' show ParameterizedType;
 import 'package:build/build.dart' show BuildStep, log;
 import 'package:code_builder/code_builder.dart' as code;
-import 'package:http_methods/http_methods.dart' show isHttpMethod;
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:shelf_router/shelf_router.dart' as shelf_router;
 import 'package:shelf_router/src/router_entry.dart' // ignore: implementation_imports
     show RouterEntry;
 import 'package:source_gen/source_gen.dart' as g;
+
+/// Returns true if [method] is a valid HTTP method.
+bool isHttpMethod(String method) {
+  switch (method.toUpperCase()) {
+    case 'GET':
+    case 'HEAD':
+    case 'POST':
+    case 'PUT':
+    case 'DELETE':
+    case 'CONNECT':
+    case 'OPTIONS':
+    case 'TRACE':
+    case 'PATCH':
+      return true;
+    default:
+      return false;
+  }
+}
 
 // Type checkers that we need later
 const _routeType = g.TypeChecker.typeNamed(

--- a/pkgs/shelf_router_generator/pubspec.yaml
+++ b/pkgs/shelf_router_generator/pubspec.yaml
@@ -18,7 +18,6 @@ dependencies:
   build: ^4.0.0
   build_config: ^1.2.0
   code_builder: ^4.2.0
-  http_methods: ^1.1.0
   shelf: ^1.1.0
   shelf_router: ^1.1.0
   source_gen: ^4.0.1


### PR DESCRIPTION
Fixes #512

Replaced the external http_methods dependency with a local isHttpMethod implementation in shelf_router and shelf_router_generator to reduce unnecessary external dependencies.