### PR TITLE
refactor: remove http_methods dependency

### DIFF
--- a/pkgs/shelf_router/lib/src/router.dart
+++ b/pkgs/shelf_router/lib/src/router.dart
@@ -15,7 +15,6 @@
 import 'dart:collection' show UnmodifiableMapView;
 import 'dart:convert';
 
-import 'package:http_methods/http_methods.dart';
 import 'package:meta/meta.dart' show sealed;
 import 'package:shelf/shelf.dart';
 
@@ -130,7 +129,7 @@ class Router {
   /// `HEAD` is always wrong. To explicitely implement a `HEAD` handler it must
   /// be registered before the `GET` handler.
   void add(String verb, String route, Function handler) {
-    if (!isHttpMethod(verb)) {
+    if (!_isHttpMethod(verb)) {
       throw ArgumentError.value(verb, 'verb', 'expected a valid HTTP method');
     }
     verb = verb.toUpperCase();
@@ -304,4 +303,9 @@ class _RouteNotFoundResponse extends Response {
       body: body ?? _message,
     );
   }
+}
+
+bool _isHttpMethod(String method) {
+  return {'GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'CONNECT', 'OPTIONS', 'TRACE', 'PATCH'}
+      .contains(method.toUpperCase());
 }

--- a/pkgs/shelf_router/pubspec.yaml
+++ b/pkgs/shelf_router/pubspec.yaml
@@ -14,7 +14,6 @@ environment:
   sdk: ^3.3.0
 
 dependencies:
-  http_methods: ^1.1.0
   meta: ^1.3.0
   shelf: ^1.0.0
 

--- a/pkgs/shelf_router_generator/lib/src/shelf_router_generator.dart
+++ b/pkgs/shelf_router_generator/lib/src/shelf_router_generator.dart
@@ -22,7 +22,6 @@ import 'package:analyzer/dart/element/element.dart'
 import 'package:analyzer/dart/element/type.dart' show ParameterizedType;
 import 'package:build/build.dart' show BuildStep, log;
 import 'package:code_builder/code_builder.dart' as code;
-import 'package:http_methods/http_methods.dart' show isHttpMethod;
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:shelf_router/shelf_router.dart' as shelf_router;
 import 'package:shelf_router/src/router_entry.dart' // ignore: implementation_imports
@@ -185,7 +184,7 @@ void _typeCheckHandler(_Handler h) {
   }
 
   // Check the verb, note that $all is a special value for handling all verbs.
-  if (!isHttpMethod(h.verb) && h.verb != r'$all') {
+  if (!_isHttpMethod(h.verb) && h.verb != r'$all') {
     throw g.InvalidGenerationSourceError(
       'The verb "${h.verb}" used in shelf_router.Route annotation must be '
       'a valid HTTP method',
@@ -336,4 +335,9 @@ void _typeCheckMount(_Handler h) {
       element: h.element,
     );
   }
+}
+
+bool _isHttpMethod(String method) {
+  return {'GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'CONNECT', 'OPTIONS', 'TRACE', 'PATCH'}
+      .contains(method.toUpperCase());
 }

--- a/pkgs/shelf_router_generator/pubspec.yaml
+++ b/pkgs/shelf_router_generator/pubspec.yaml
@@ -18,7 +18,6 @@ dependencies:
   build: ^4.0.0
   build_config: ^1.2.0
   code_builder: ^4.2.0
-  http_methods: ^1.1.0
   shelf: ^1.1.0
   shelf_router: ^1.1.0
   source_gen: ^4.0.1


### PR DESCRIPTION
Fixes #512 by removing the `http_methods` dependency and inlining a simple `_isHttpMethod` check. This reduces dependencies outside the Dart team and facilitates using `shelf_router` in the Dart SDK.