### PR TITLE
Fix multi-header handling in shelf_proxy

### DIFF
--- a/pkgs/shelf_proxy/CHANGELOG.md
+++ b/pkgs/shelf_proxy/CHANGELOG.md
@@ -1,5 +1,8 @@
-## 1.0.5-wip
+## 1.0.5
 
+* Correctly handle multiple `Cookie` headers in requests and `Set-Cookie`
+  headers in responses.
+* Require `package:http` `^1.2.0`.
 * Require Dart `^3.3.0`.
 
 ## 1.0.4

--- a/pkgs/shelf_proxy/lib/shelf_proxy.dart
+++ b/pkgs/shelf_proxy/lib/shelf_proxy.dart
@@ -44,6 +44,9 @@ Handler proxyHandler(Object url, {http.Client? client, String? proxyName}) {
       ..followRedirects = false;
 
     serverRequest.headersAll.forEach((name, values) {
+      // The Cookie header is special: multiple cookies are joined with a
+      // semicolon and a space, while other headers use a comma.
+      // See https://datatracker.ietf.org/doc/html/rfc6265#section-5.4
       clientRequest.headers[name] =
           values.join(name.toLowerCase() == 'cookie' ? '; ' : ', ');
     });
@@ -76,7 +79,7 @@ Handler proxyHandler(Object url, {http.Client? client, String? proxyName}) {
 
     // If the original response was gzipped, it will be decoded by [client]
     // and we'll have no way of knowing its actual content-length.
-    if (headers['content-encoding'] == 'gzip') {
+    if (headersAll['content-encoding']?.contains('gzip') ?? false) {
       headersAll.remove('content-encoding');
       headersAll.remove('content-length');
 

--- a/pkgs/shelf_proxy/lib/shelf_proxy.dart
+++ b/pkgs/shelf_proxy/lib/shelf_proxy.dart
@@ -61,48 +61,47 @@ Handler proxyHandler(Object url, {http.Client? client, String? proxyName}) {
         .whenComplete(clientRequest.sink.close)
         .ignore();
     final clientResponse = await nonNullClient.send(clientRequest);
-
-    final responseHeaders =
+    final headers = clientResponse.headers;
+    final headersAll =
         Map<String, List<String>>.from(clientResponse.headersSplitValues);
 
     // Add a Via header. See
     // http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.45
-    responseHeaders.update('via', (values) => [...values, '1.1 $proxyName'],
+    headersAll.update('via', (values) => [...values, '1.1 $proxyName'],
         ifAbsent: () => ['1.1 $proxyName']);
 
     // Remove the transfer-encoding since the body has already been decoded by
     // [client].
-    responseHeaders.remove('transfer-encoding');
+    headersAll.remove('transfer-encoding');
 
     // If the original response was gzipped, it will be decoded by [client]
     // and we'll have no way of knowing its actual content-length.
-    if (responseHeaders['content-encoding']?.contains('gzip') ?? false) {
-      responseHeaders.remove('content-encoding');
-      responseHeaders.remove('content-length');
+    if (headers['content-encoding'] == 'gzip') {
+      headersAll.remove('content-encoding');
+      headersAll.remove('content-length');
 
       // Add a Warning header. See
       // http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html#sec13.5.2
-      responseHeaders.update(
+      headersAll.update(
           'warning', (values) => [...values, '214 $proxyName "GZIP decoded"'],
           ifAbsent: () => ['214 $proxyName "GZIP decoded"']);
     }
 
     // Make sure the Location header is pointing to the proxy server rather
     // than the destination server, if possible.
-    if (clientResponse.isRedirect && responseHeaders.containsKey('location')) {
-      final location =
-          requestUrl.resolve(responseHeaders['location']!.first).toString();
+    if (clientResponse.isRedirect && headers.containsKey('location')) {
+      final location = requestUrl.resolve(headers['location']!).toString();
       if (p.url.isWithin(uri.toString(), location)) {
-        responseHeaders['location'] = [
+        headersAll['location'] = [
           '/${p.url.relative(location, from: uri.toString())}'
         ];
       } else {
-        responseHeaders['location'] = [location];
+        headersAll['location'] = [location];
       }
     }
 
     return Response(clientResponse.statusCode,
-        body: clientResponse.stream, headers: responseHeaders);
+        body: clientResponse.stream, headers: headersAll);
   };
 }
 

--- a/pkgs/shelf_proxy/lib/shelf_proxy.dart
+++ b/pkgs/shelf_proxy/lib/shelf_proxy.dart
@@ -41,9 +41,13 @@ Handler proxyHandler(Object url, {http.Client? client, String? proxyName}) {
     // http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.8
     final requestUrl = uri.resolve(serverRequest.url.toString());
     final clientRequest = http.StreamedRequest(serverRequest.method, requestUrl)
-      ..followRedirects = false
-      ..headers.addAll(serverRequest.headers)
-      ..headers['Host'] = uri.authority;
+      ..followRedirects = false;
+
+    serverRequest.headersAll.forEach((name, values) {
+      clientRequest.headers[name] =
+          values.join(name.toLowerCase() == 'cookie' ? '; ' : ', ');
+    });
+    clientRequest.headers['Host'] = uri.authority;
 
     // Add a Via header. See
     // http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.45
@@ -57,42 +61,48 @@ Handler proxyHandler(Object url, {http.Client? client, String? proxyName}) {
         .whenComplete(clientRequest.sink.close)
         .ignore();
     final clientResponse = await nonNullClient.send(clientRequest);
+
+    final responseHeaders =
+        Map<String, List<String>>.from(clientResponse.headersSplitValues);
+
     // Add a Via header. See
     // http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.45
-    _addHeader(clientResponse.headers, 'via', '1.1 $proxyName');
+    responseHeaders.update('via', (values) => [...values, '1.1 $proxyName'],
+        ifAbsent: () => ['1.1 $proxyName']);
 
     // Remove the transfer-encoding since the body has already been decoded by
     // [client].
-    clientResponse.headers.remove('transfer-encoding');
+    responseHeaders.remove('transfer-encoding');
 
     // If the original response was gzipped, it will be decoded by [client]
     // and we'll have no way of knowing its actual content-length.
-    if (clientResponse.headers['content-encoding'] == 'gzip') {
-      clientResponse.headers.remove('content-encoding');
-      clientResponse.headers.remove('content-length');
+    if (responseHeaders['content-encoding']?.contains('gzip') ?? false) {
+      responseHeaders.remove('content-encoding');
+      responseHeaders.remove('content-length');
 
       // Add a Warning header. See
       // http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html#sec13.5.2
-      _addHeader(
-          clientResponse.headers, 'warning', '214 $proxyName "GZIP decoded"');
+      responseHeaders.update(
+          'warning', (values) => [...values, '214 $proxyName "GZIP decoded"'],
+          ifAbsent: () => ['214 $proxyName "GZIP decoded"']);
     }
 
     // Make sure the Location header is pointing to the proxy server rather
     // than the destination server, if possible.
-    if (clientResponse.isRedirect &&
-        clientResponse.headers.containsKey('location')) {
+    if (clientResponse.isRedirect && responseHeaders.containsKey('location')) {
       final location =
-          requestUrl.resolve(clientResponse.headers['location']!).toString();
+          requestUrl.resolve(responseHeaders['location']!.first).toString();
       if (p.url.isWithin(uri.toString(), location)) {
-        clientResponse.headers['location'] =
-            '/${p.url.relative(location, from: uri.toString())}';
+        responseHeaders['location'] = [
+          '/${p.url.relative(location, from: uri.toString())}'
+        ];
       } else {
-        clientResponse.headers['location'] = location;
+        responseHeaders['location'] = [location];
       }
     }
 
     return Response(clientResponse.statusCode,
-        body: clientResponse.stream, headers: clientResponse.headers);
+        body: clientResponse.stream, headers: responseHeaders);
   };
 }
 

--- a/pkgs/shelf_proxy/pubspec.yaml
+++ b/pkgs/shelf_proxy/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf_proxy
-version: 1.0.5-wip
+version: 1.0.5
 description: A shelf handler for proxying HTTP requests to another server.
 repository: https://github.com/dart-lang/shelf/tree/master/pkgs/shelf_proxy
 issue_tracker: https://github.com/dart-lang/shelf/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Ashelf_proxy
@@ -12,7 +12,7 @@ environment:
   sdk: ^3.3.0
 
 dependencies:
-  http: '>=0.13.0 <2.0.0'
+  http: ^1.2.0
   path: ^1.8.0
   shelf: ^1.0.0
 

--- a/pkgs/shelf_proxy/test/shelf_proxy_test.dart
+++ b/pkgs/shelf_proxy/test/shelf_proxy_test.dart
@@ -89,7 +89,8 @@ void main() {
       final client = http.Client();
       final response = await client.get(proxyUri);
 
-      // We use headersSplitValues to verify that they are preserved as separate values.
+      // We use headersSplitValues to verify that they are preserved as separate
+      // values.
       expect(response.headersSplitValues['set-cookie'],
           containsAll(['cookie1=value1', 'cookie2=value2']));
     });

--- a/pkgs/shelf_proxy/test/shelf_proxy_test.dart
+++ b/pkgs/shelf_proxy/test/shelf_proxy_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
@@ -79,20 +80,25 @@ void main() {
       expect(response.headers, containsPair('accept', '*/*'));
     });
 
-    test('preserves multiple Set-Cookie headers in response', () async {
+    test('preserves multiple Set-Cookie headers in response, including dates', () async {
       await createProxy((request) {
         return shelf.Response.ok(':)', headers: {
-          'set-cookie': ['cookie1=value1', 'cookie2=value2'],
+          'set-cookie': [
+            'cookie1=value1; Expires=Mon, 20 Apr 2026 17:22:59 GMT',
+            'cookie2=value2'
+          ],
         });
       });
 
-      final client = http.Client();
-      final response = await client.get(proxyUri);
+      final client = HttpClient();
+      final request = await client.getUrl(proxyUri);
+      final response = await request.close();
 
-      // We use headersSplitValues to verify that they are preserved as separate
-      // values.
-      expect(response.headersSplitValues['set-cookie'],
-          containsAll(['cookie1=value1', 'cookie2=value2']));
+      final setCookies = response.headers['set-cookie'];
+      expect(setCookies, [
+        'cookie1=value1; Expires=Mon, 20 Apr 2026 17:22:59 GMT',
+        'cookie2=value2'
+      ]);
     });
 
     test('forwards response body', () async {

--- a/pkgs/shelf_proxy/test/shelf_proxy_test.dart
+++ b/pkgs/shelf_proxy/test/shelf_proxy_test.dart
@@ -38,6 +38,19 @@ void main() {
       await get(headers: {'foo': 'bar', 'accept': '*/*'});
     });
 
+    test('joins multiple request cookies with a semicolon', () async {
+      final client = MockClient((request) {
+        expect(request.headers,
+            containsPair('cookie', 'cookie1=value1; cookie2=value2'));
+        return Future.value(http.Response(':)', 200));
+      });
+
+      final handler = proxyHandler('http://dartlang.org', client: client);
+      final request = shelf.Request('GET', Uri.parse('http://localhost/'),
+          headers: {'cookie': ['cookie1=value1', 'cookie2=value2']});
+      await handler(request);
+    });
+
     test('forwards request body', () async {
       await createProxy((request) {
         expect(request.readAsString(), completion(equals('hello, server')));
@@ -62,6 +75,21 @@ void main() {
 
       expect(response.headers, containsPair('foo', 'bar'));
       expect(response.headers, containsPair('accept', '*/*'));
+    });
+
+    test('preserves multiple Set-Cookie headers in response', () async {
+      await createProxy((request) {
+        return shelf.Response.ok(':)', headers: {
+          'set-cookie': ['cookie1=value1', 'cookie2=value2'],
+        });
+      });
+
+      final client = http.Client();
+      final response = await client.get(proxyUri);
+
+      // We use headersSplitValues to verify that they are preserved as separate values.
+      expect(response.headersSplitValues['set-cookie'],
+          containsAll(['cookie1=value1', 'cookie2=value2']));
     });
 
     test('forwards response body', () async {

--- a/pkgs/shelf_proxy/test/shelf_proxy_test.dart
+++ b/pkgs/shelf_proxy/test/shelf_proxy_test.dart
@@ -80,7 +80,8 @@ void main() {
       expect(response.headers, containsPair('accept', '*/*'));
     });
 
-    test('preserves multiple Set-Cookie headers in response, including dates', () async {
+    test('preserves multiple Set-Cookie headers in response, including dates',
+        () async {
       await createProxy((request) {
         return shelf.Response.ok(':)', headers: {
           'set-cookie': [

--- a/pkgs/shelf_proxy/test/shelf_proxy_test.dart
+++ b/pkgs/shelf_proxy/test/shelf_proxy_test.dart
@@ -46,8 +46,10 @@ void main() {
       });
 
       final handler = proxyHandler('http://dartlang.org', client: client);
-      final request = shelf.Request('GET', Uri.parse('http://localhost/'),
-          headers: {'cookie': ['cookie1=value1', 'cookie2=value2']});
+      final request =
+          shelf.Request('GET', Uri.parse('http://localhost/'), headers: {
+        'cookie': ['cookie1=value1', 'cookie2=value2']
+      });
       await handler(request);
     });
 


### PR DESCRIPTION
Because `shelf_proxy` uses `http.Response.headers`, all the multi-headers are merged into a single header. This is causing the issue filed at: https://github.com/flutter/flutter/issues/178582

The fix is to use `http.Response.headersSplitValues` which preserves multi-headers in a `Map<String, List<String>>`.