### PR TITLE
chore: bump pkg:shelf min SDK to Dart 3.9

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -97,36 +97,6 @@ jobs:
         if: "always() && steps.pkgs_shelf_static_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/shelf_static
   job_003:
-    name: "analyze_and_format; linux; Dart 3.4.0; PKG: pkgs/shelf; `dart analyze --fatal-infos .`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:pkgs/shelf;commands:analyze"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:pkgs/shelf
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
-        with:
-          sdk: "3.4.0"
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - id: pkgs_shelf_pub_upgrade
-        name: pkgs/shelf; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/shelf
-      - name: "pkgs/shelf; dart analyze --fatal-infos ."
-        run: dart analyze --fatal-infos .
-        if: "always() && steps.pkgs_shelf_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/shelf
-  job_004:
     name: "analyze_and_format; linux; Dart 3.5.0; PKGS: pkgs/shelf_test_handler, pkgs/shelf_web_socket; `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
@@ -165,17 +135,17 @@ jobs:
         run: dart analyze --fatal-infos .
         if: "always() && steps.pkgs_shelf_web_socket_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/shelf_web_socket
-  job_005:
-    name: "analyze_and_format; linux; Dart 3.9.0; PKG: pkgs/shelf_router_generator; `dart analyze --fatal-infos .`"
+  job_004:
+    name: "analyze_and_format; linux; Dart 3.9.0; PKGS: pkgs/shelf, pkgs/shelf_router_generator; `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.9.0;packages:pkgs/shelf_router_generator;commands:analyze"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.9.0;packages:pkgs/shelf-pkgs/shelf_router_generator;commands:analyze"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.9.0;packages:pkgs/shelf_router_generator
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.9.0;packages:pkgs/shelf-pkgs/shelf_router_generator
             os:ubuntu-latest;pub-cache-hosted;sdk:3.9.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -186,6 +156,15 @@ jobs:
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - id: pkgs_shelf_pub_upgrade
+        name: pkgs/shelf; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/shelf
+      - name: "pkgs/shelf; dart analyze --fatal-infos ."
+        run: dart analyze --fatal-infos .
+        if: "always() && steps.pkgs_shelf_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/shelf
       - id: pkgs_shelf_router_generator_pub_upgrade
         name: pkgs/shelf_router_generator; dart pub upgrade
         run: dart pub upgrade
@@ -195,7 +174,7 @@ jobs:
         run: dart analyze --fatal-infos .
         if: "always() && steps.pkgs_shelf_router_generator_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/shelf_router_generator
-  job_006:
+  job_005:
     name: "analyze_and_format; linux; Dart dev; PKGS: pkgs/_shelf_compliance, pkgs/shelf, pkgs/shelf_packages_handler, pkgs/shelf_proxy, pkgs/shelf_router, pkgs/shelf_router_generator, pkgs/shelf_static, pkgs/shelf_test_handler, pkgs/shelf_web_socket; `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
@@ -297,7 +276,7 @@ jobs:
         run: dart analyze --fatal-infos .
         if: "always() && steps.pkgs_shelf_web_socket_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/shelf_web_socket
-  job_007:
+  job_006:
     name: "analyze_and_format; linux; Dart dev; PKGS: pkgs/_shelf_compliance, pkgs/shelf, pkgs/shelf_packages_handler, pkgs/shelf_proxy, pkgs/shelf_router, pkgs/shelf_router_generator, pkgs/shelf_static, pkgs/shelf_test_handler, pkgs/shelf_web_socket; `dart format --output=none --set-exit-if-changed .`"
     runs-on: ubuntu-latest
     steps:
@@ -399,7 +378,7 @@ jobs:
         run: "dart format --output=none --set-exit-if-changed ."
         if: "always() && steps.pkgs_shelf_web_socket_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/shelf_web_socket
-  job_008:
+  job_007:
     name: "unit_test; linux; Dart 3.3.0; PKGS: pkgs/shelf_packages_handler, pkgs/shelf_proxy, pkgs/shelf_router, pkgs/shelf_static; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -463,84 +442,7 @@ jobs:
       - job_004
       - job_005
       - job_006
-      - job_007
-  job_009:
-    name: "unit_test; linux; Dart 3.4.0; PKG: pkgs/shelf; `dart test --test-randomize-ordering-seed=random -p chrome`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:pkgs/shelf;commands:test_1"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:pkgs/shelf
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
-        with:
-          sdk: "3.4.0"
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - id: pkgs_shelf_pub_upgrade
-        name: pkgs/shelf; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/shelf
-      - name: "pkgs/shelf; dart test --test-randomize-ordering-seed=random -p chrome"
-        run: "dart test --test-randomize-ordering-seed=random -p chrome"
-        if: "always() && steps.pkgs_shelf_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/shelf
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-      - job_005
-      - job_006
-      - job_007
-  job_010:
-    name: "unit_test; linux; Dart 3.4.0; PKG: pkgs/shelf; `dart test --test-randomize-ordering-seed=random`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:pkgs/shelf;commands:test_0"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:pkgs/shelf
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
-        with:
-          sdk: "3.4.0"
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - id: pkgs_shelf_pub_upgrade
-        name: pkgs/shelf; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/shelf
-      - name: "pkgs/shelf; dart test --test-randomize-ordering-seed=random"
-        run: "dart test --test-randomize-ordering-seed=random"
-        if: "always() && steps.pkgs_shelf_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/shelf
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-      - job_005
-      - job_006
-      - job_007
-  job_011:
+  job_008:
     name: "unit_test; linux; Dart 3.5.0; PKG: pkgs/shelf_test_handler; `dart test --test-randomize-ordering-seed=random -p chrome`"
     runs-on: ubuntu-latest
     steps:
@@ -577,8 +479,7 @@ jobs:
       - job_004
       - job_005
       - job_006
-      - job_007
-  job_012:
+  job_009:
     name: "unit_test; linux; Dart 3.5.0; PKGS: pkgs/shelf_test_handler, pkgs/shelf_web_socket; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -624,18 +525,17 @@ jobs:
       - job_004
       - job_005
       - job_006
-      - job_007
-  job_013:
-    name: "unit_test; linux; Dart 3.9.0; PKG: pkgs/shelf_router_generator; `dart test --test-randomize-ordering-seed=random`"
+  job_010:
+    name: "unit_test; linux; Dart 3.9.0; PKG: pkgs/shelf; `dart test --test-randomize-ordering-seed=random -p chrome`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.9.0;packages:pkgs/shelf_router_generator;commands:test_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.9.0;packages:pkgs/shelf;commands:test_1"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.9.0;packages:pkgs/shelf_router_generator
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.9.0;packages:pkgs/shelf
             os:ubuntu-latest;pub-cache-hosted;sdk:3.9.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -646,6 +546,52 @@ jobs:
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - id: pkgs_shelf_pub_upgrade
+        name: pkgs/shelf; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/shelf
+      - name: "pkgs/shelf; dart test --test-randomize-ordering-seed=random -p chrome"
+        run: "dart test --test-randomize-ordering-seed=random -p chrome"
+        if: "always() && steps.pkgs_shelf_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/shelf
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+      - job_006
+  job_011:
+    name: "unit_test; linux; Dart 3.9.0; PKGS: pkgs/shelf, pkgs/shelf_router_generator; `dart test --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.9.0;packages:pkgs/shelf-pkgs/shelf_router_generator;commands:test_0"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.9.0;packages:pkgs/shelf-pkgs/shelf_router_generator
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.9.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
+        with:
+          sdk: "3.9.0"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - id: pkgs_shelf_pub_upgrade
+        name: pkgs/shelf; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/shelf
+      - name: "pkgs/shelf; dart test --test-randomize-ordering-seed=random"
+        run: "dart test --test-randomize-ordering-seed=random"
+        if: "always() && steps.pkgs_shelf_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/shelf
       - id: pkgs_shelf_router_generator_pub_upgrade
         name: pkgs/shelf_router_generator; dart pub upgrade
         run: dart pub upgrade
@@ -662,8 +608,7 @@ jobs:
       - job_004
       - job_005
       - job_006
-      - job_007
-  job_014:
+  job_012:
     name: "unit_test; linux; Dart dev; PKGS: pkgs/shelf, pkgs/shelf_test_handler; `dart test --test-randomize-ordering-seed=random -p chrome -c dart2wasm`"
     runs-on: ubuntu-latest
     steps:
@@ -709,8 +654,7 @@ jobs:
       - job_004
       - job_005
       - job_006
-      - job_007
-  job_015:
+  job_013:
     name: "unit_test; linux; Dart dev; PKGS: pkgs/shelf, pkgs/shelf_test_handler; `dart test --test-randomize-ordering-seed=random -p chrome`"
     runs-on: ubuntu-latest
     steps:
@@ -756,8 +700,7 @@ jobs:
       - job_004
       - job_005
       - job_006
-      - job_007
-  job_016:
+  job_014:
     name: "unit_test; linux; Dart dev; PKGS: pkgs/shelf, pkgs/shelf_packages_handler, pkgs/shelf_proxy, pkgs/shelf_router, pkgs/shelf_router_generator, pkgs/shelf_static, pkgs/shelf_test_handler, pkgs/shelf_web_socket; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -857,8 +800,7 @@ jobs:
       - job_004
       - job_005
       - job_006
-      - job_007
-  job_017:
+  job_015:
     name: "unit_test; linux; Dart dev; PKG: pkgs/shelf_router_generator; `dart test --run-skipped -t presubmit-only`"
     runs-on: ubuntu-latest
     steps:
@@ -895,8 +837,7 @@ jobs:
       - job_004
       - job_005
       - job_006
-      - job_007
-  job_018:
+  job_016:
     name: "unit_test; windows; Dart 3.3.0; PKGS: pkgs/shelf_packages_handler, pkgs/shelf_static; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -932,36 +873,7 @@ jobs:
       - job_004
       - job_005
       - job_006
-      - job_007
-  job_019:
-    name: "unit_test; windows; Dart 3.4.0; PKG: pkgs/shelf; `dart test --test-randomize-ordering-seed=random -p chrome`"
-    runs-on: windows-latest
-    steps:
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
-        with:
-          sdk: "3.4.0"
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - id: pkgs_shelf_pub_upgrade
-        name: pkgs/shelf; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/shelf
-      - name: "pkgs/shelf; dart test --test-randomize-ordering-seed=random -p chrome"
-        run: "dart test --test-randomize-ordering-seed=random -p chrome"
-        if: "always() && steps.pkgs_shelf_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/shelf
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-      - job_005
-      - job_006
-      - job_007
-  job_020:
+  job_017:
     name: "unit_test; windows; Dart 3.5.0; PKG: pkgs/shelf_test_handler; `dart test --test-randomize-ordering-seed=random -p chrome`"
     runs-on: windows-latest
     steps:
@@ -988,8 +900,7 @@ jobs:
       - job_004
       - job_005
       - job_006
-      - job_007
-  job_021:
+  job_018:
     name: "unit_test; windows; Dart 3.5.0; PKGS: pkgs/shelf_test_handler, pkgs/shelf_web_socket; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1025,8 +936,34 @@ jobs:
       - job_004
       - job_005
       - job_006
-      - job_007
-  job_022:
+  job_019:
+    name: "unit_test; windows; Dart 3.9.0; PKG: pkgs/shelf; `dart test --test-randomize-ordering-seed=random -p chrome`"
+    runs-on: windows-latest
+    steps:
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
+        with:
+          sdk: "3.9.0"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - id: pkgs_shelf_pub_upgrade
+        name: pkgs/shelf; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/shelf
+      - name: "pkgs/shelf; dart test --test-randomize-ordering-seed=random -p chrome"
+        run: "dart test --test-randomize-ordering-seed=random -p chrome"
+        if: "always() && steps.pkgs_shelf_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/shelf
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+      - job_006
+  job_020:
     name: "unit_test; windows; Dart dev; PKGS: pkgs/shelf, pkgs/shelf_test_handler; `dart test --test-randomize-ordering-seed=random -p chrome`"
     runs-on: windows-latest
     steps:
@@ -1062,8 +999,7 @@ jobs:
       - job_004
       - job_005
       - job_006
-      - job_007
-  job_023:
+  job_021:
     name: "unit_test; windows; Dart dev; PKGS: pkgs/shelf_packages_handler, pkgs/shelf_static, pkgs/shelf_test_handler, pkgs/shelf_web_socket; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1117,4 +1053,3 @@ jobs:
       - job_004
       - job_005
       - job_006
-      - job_007

--- a/pkgs/shelf/CHANGELOG.md
+++ b/pkgs/shelf/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 1.4.3-wip
 
+* Require `sdk: ^3.9.0`.
+
 ## 1.4.2
 
 * `Headers`: added the `fromEntries`  constructor.

--- a/pkgs/shelf/benchmark/pipeline_benchmark.dart
+++ b/pkgs/shelf/benchmark/pipeline_benchmark.dart
@@ -6,11 +6,26 @@ import 'package:shelf/shelf.dart';
 
 void main() async {
   final handler = const Pipeline()
-      .addMiddleware((innerHandler) => (request) => innerHandler(request))
-      .addMiddleware((innerHandler) => (request) => innerHandler(request))
-      .addMiddleware((innerHandler) => (request) => innerHandler(request))
-      .addMiddleware((innerHandler) => (request) => innerHandler(request))
-      .addMiddleware((innerHandler) => (request) => innerHandler(request))
+      .addMiddleware(
+        (innerHandler) =>
+            (request) => innerHandler(request),
+      )
+      .addMiddleware(
+        (innerHandler) =>
+            (request) => innerHandler(request),
+      )
+      .addMiddleware(
+        (innerHandler) =>
+            (request) => innerHandler(request),
+      )
+      .addMiddleware(
+        (innerHandler) =>
+            (request) => innerHandler(request),
+      )
+      .addMiddleware(
+        (innerHandler) =>
+            (request) => innerHandler(request),
+      )
       .addHandler((request) => Response.ok('hello world'));
 
   final url = Uri.http('localhost:8080', '/');
@@ -36,5 +51,6 @@ void main() async {
   sw.stop();
   print('Total time: ${sw.elapsedMilliseconds} ms');
   print(
-      'Req/sec: ${(iterations / sw.elapsedMicroseconds * 1000000).toStringAsFixed(2)}');
+    'Req/sec: ${(iterations / sw.elapsedMicroseconds * 1000000).toStringAsFixed(2)}',
+  );
 }

--- a/pkgs/shelf/example/example.dart
+++ b/pkgs/shelf/example/example.dart
@@ -6,8 +6,9 @@ import 'package:shelf/shelf.dart';
 import 'package:shelf/shelf_io.dart' as shelf_io;
 
 void main() async {
-  var handler =
-      const Pipeline().addMiddleware(logRequests()).addHandler(_echoRequest);
+  var handler = const Pipeline()
+      .addMiddleware(logRequests())
+      .addHandler(_echoRequest);
 
   var server = await shelf_io.serve(handler, 'localhost', 8080);
 

--- a/pkgs/shelf/lib/shelf_io.dart
+++ b/pkgs/shelf/lib/shelf_io.dart
@@ -88,12 +88,17 @@ void serveRequests(
   Handler handler, {
   String? poweredByHeader = 'Dart with package:shelf',
 }) {
-  catchTopLevelErrors(() {
-    requests.listen((request) =>
-        handleRequest(request, handler, poweredByHeader: poweredByHeader));
-  }, (error, stackTrace) {
-    _logTopLevelError('Asynchronous error\n$error', stackTrace);
-  });
+  catchTopLevelErrors(
+    () {
+      requests.listen(
+        (request) =>
+            handleRequest(request, handler, poweredByHeader: poweredByHeader),
+      );
+    },
+    (error, stackTrace) {
+      _logTopLevelError('Asynchronous error\n$error', stackTrace);
+    },
+  );
 }
 
 /// Uses [handler] to handle [request].
@@ -162,8 +167,10 @@ Future<void> handleRequest(
   }
 
   var message = StringBuffer()
-    ..writeln('Got a response for hijacked request '
-        '${shelfRequest.method} ${shelfRequest.requestedUri}:')
+    ..writeln(
+      'Got a response for hijacked request '
+      '${shelfRequest.method} ${shelfRequest.requestedUri}:',
+    )
     ..writeln(response.statusCode);
   response.headers.forEach((key, value) => message.writeln('$key: $value'));
   throw Exception(message.toString().trim());
@@ -197,7 +204,10 @@ Request _fromHttpRequest(HttpRequest request) {
 }
 
 Future<void> _writeResponse(
-    Response response, HttpResponse httpResponse, String? poweredByHeader) {
+  Response response,
+  HttpResponse httpResponse,
+  String? poweredByHeader,
+) {
   if (response.context.containsKey('shelf.io.buffer_output')) {
     httpResponse.bufferOutput =
         response.context['shelf.io.buffer_output'] as bool;
@@ -271,9 +281,9 @@ Response _logError(Request request, String message, StackTrace stackTrace) {
 }
 
 void _logTopLevelError(String message, StackTrace stackTrace) {
-  final chain = Chain.forTrace(stackTrace)
-      .foldFrames((frame) => frame.isCore || frame.package == 'shelf')
-      .terse;
+  final chain = Chain.forTrace(
+    stackTrace,
+  ).foldFrames((frame) => frame.isCore || frame.package == 'shelf').terse;
 
   stderr.writeln('ERROR - ${DateTime.now()}');
   stderr.writeln(message);

--- a/pkgs/shelf/lib/src/body.dart
+++ b/pkgs/shelf/lib/src/body.dart
@@ -67,8 +67,10 @@ class Body {
     } else if (body is Stream) {
       stream = body.cast();
     } else {
-      throw ArgumentError('Response body "$body" must be a String or a '
-          'Stream.');
+      throw ArgumentError(
+        'Response body "$body" must be a String or a '
+        'Stream.',
+      );
     }
 
     return Body._(stream, encoding, contentLength);
@@ -92,8 +94,10 @@ class Body {
   /// Can only be called once.
   Stream<List<int>> read() {
     if (_stream == null) {
-      throw StateError("The 'read' method can only be called once on a "
-          'shelf.Request/shelf.Response object.');
+      throw StateError(
+        "The 'read' method can only be called once on a "
+        'shelf.Request/shelf.Response object.',
+      );
     }
     var stream = _stream!;
     _stream = null;

--- a/pkgs/shelf/lib/src/cascade.dart
+++ b/pkgs/shelf/lib/src/cascade.dart
@@ -42,12 +42,14 @@ class Cascade {
   /// it returns `true` are considered unacceptable. [statusCodes] and
   /// [shouldCascade] may not both be passed.
   Cascade({Iterable<int>? statusCodes, bool Function(Response)? shouldCascade})
-      : _shouldCascade = _computeShouldCascade(statusCodes, shouldCascade),
-        _parent = null,
-        _handler = null {
+    : _shouldCascade = _computeShouldCascade(statusCodes, shouldCascade),
+      _parent = null,
+      _handler = null {
     if (statusCodes != null && shouldCascade != null) {
-      throw ArgumentError('statusCodes and shouldCascade may not both be '
-          'passed.');
+      throw ArgumentError(
+        'statusCodes and shouldCascade may not both be '
+        'passed.',
+      );
     }
   }
 
@@ -67,8 +69,10 @@ class Cascade {
   Handler get handler {
     final handler = _handler;
     if (handler == null) {
-      throw StateError("Can't get a handler for a cascade with no inner "
-          'handlers.');
+      throw StateError(
+        "Can't get a handler for a cascade with no inner "
+        'handlers.',
+      );
     }
 
     return (request) {
@@ -84,7 +88,9 @@ class Cascade {
 /// Computes the [Cascade._shouldCascade] function based on the user's
 /// parameters.
 _ShouldCascade _computeShouldCascade(
-    Iterable<int>? statusCodes, bool Function(Response)? shouldCascade) {
+  Iterable<int>? statusCodes,
+  bool Function(Response)? shouldCascade,
+) {
   if (shouldCascade != null) return shouldCascade;
   statusCodes ??= [404, 405];
   final statusCodeSet = statusCodes.toSet();

--- a/pkgs/shelf/lib/src/headers.dart
+++ b/pkgs/shelf/lib/src/headers.dart
@@ -39,13 +39,13 @@ class Headers extends UnmodifiableMapView<String, List<String>> {
   }
 
   Headers._(Iterable<MapEntry<String, List<String>>> entries)
-      : super(
-          CaseInsensitiveMap.fromEntries(
-            entries
-                .where((e) => e.value.isNotEmpty)
-                .map((e) => MapEntry(e.key, List.unmodifiable(e.value))),
-          ),
-        );
+    : super(
+        CaseInsensitiveMap.fromEntries(
+          entries
+              .where((e) => e.value.isNotEmpty)
+              .map((e) => MapEntry(e.key, List.unmodifiable(e.value))),
+        ),
+      );
 
   Headers._empty() : super(const {});
 

--- a/pkgs/shelf/lib/src/io_server.dart
+++ b/pkgs/shelf/lib/src/io_server.dart
@@ -27,9 +27,10 @@ class IOServer implements Server {
     // URL ambiguity with the ":" in the address.
     if (server.address.type == InternetAddressType.IPv6) {
       return Uri(
-          scheme: 'http',
-          host: '[${server.address.address}]',
-          port: server.port);
+        scheme: 'http',
+        host: '[${server.address.address}]',
+        port: server.port,
+      );
     }
 
     return Uri(scheme: 'http', host: server.address.address, port: server.port);

--- a/pkgs/shelf/lib/src/message.dart
+++ b/pkgs/shelf/lib/src/message.dart
@@ -88,18 +88,22 @@ abstract class Message {
   }) : this._withBody(Body(body, encoding), headers, context);
 
   Message._withBody(
-      Body body, Map<String, Object>? headers, Map<String, Object>? context)
-      : this._withHeadersAll(
-          body,
-          Headers.from(_adjustHeaders(expandToHeadersAll(headers), body)),
-          context,
-        );
+    Body body,
+    Map<String, Object>? headers,
+    Map<String, Object>? context,
+  ) : this._withHeadersAll(
+        body,
+        Headers.from(_adjustHeaders(expandToHeadersAll(headers), body)),
+        context,
+      );
 
   Message._withHeadersAll(
-      Body body, Headers headers, Map<String, Object>? context)
-      : _body = body,
-        _headers = headers,
-        context = ShelfUnmodifiableMap(context, ignoreKeyCase: false);
+    Body body,
+    Headers headers,
+    Map<String, Object>? context,
+  ) : _body = body,
+      _headers = headers,
+      context = ShelfUnmodifiableMap(context, ignoreKeyCase: false);
 
   /// The contents of the content-length field in [headers].
   ///
@@ -170,8 +174,11 @@ abstract class Message {
 
   /// Creates a new [Message] by copying existing values and applying specified
   /// changes.
-  Message change(
-      {Map<String, String> headers, Map<String, Object> context, Object? body});
+  Message change({
+    Map<String, String> headers,
+    Map<String, Object> context,
+    Object? body,
+  });
 }
 
 /// Adds information about encoding to [headers].
@@ -199,12 +206,12 @@ Map<String, List<String>> _adjustHeaders(
   if (!sameEncoding) {
     if (newHeaders['content-type'] == null) {
       newHeaders['content-type'] = [
-        'application/octet-stream; charset=${body.encoding!.name}'
+        'application/octet-stream; charset=${body.encoding!.name}',
       ];
     } else {
-      final contentType =
-          MediaType.parse(joinHeaderValues(newHeaders['content-type'])!)
-              .change(parameters: {'charset': body.encoding!.name});
+      final contentType = MediaType.parse(
+        joinHeaderValues(newHeaders['content-type'])!,
+      ).change(parameters: {'charset': body.encoding!.name});
       newHeaders['content-type'] = [contentType.toString()];
     }
   }

--- a/pkgs/shelf/lib/src/middleware.dart
+++ b/pkgs/shelf/lib/src/middleware.dart
@@ -67,8 +67,9 @@ Middleware createMiddleware({
       return Future.sync(() => requestHandler!(request)).then((response) {
         if (response != null) return response;
 
-        return Future.sync(() => innerHandler(request))
-            .then((response) => responseHandler!(response), onError: onError);
+        return Future.sync(
+          () => innerHandler(request),
+        ).then((response) => responseHandler!(response), onError: onError);
       });
     };
   };

--- a/pkgs/shelf/lib/src/middleware/add_chunked_encoding.dart
+++ b/pkgs/shelf/lib/src/middleware/add_chunked_encoding.dart
@@ -18,21 +18,24 @@ import '../middleware.dart';
 /// This is intended for use by
 /// [Shelf adapters](https://pub.dev/packages/shelf#adapters) rather than
 /// end-users.
-final addChunkedEncoding = createMiddleware(responseHandler: (response) {
-  if (response.contentLength != null) return response;
-  if (response.statusCode < 200) return response;
-  if (response.statusCode == 204) return response;
-  if (response.statusCode == 304) return response;
-  if (response.mimeType == 'multipart/byteranges') return response;
+final addChunkedEncoding = createMiddleware(
+  responseHandler: (response) {
+    if (response.contentLength != null) return response;
+    if (response.statusCode < 200) return response;
+    if (response.statusCode == 204) return response;
+    if (response.statusCode == 304) return response;
+    if (response.mimeType == 'multipart/byteranges') return response;
 
-  // We only check the last coding here because HTTP requires that the chunked
-  // encoding be listed last.
-  var coding = response.headers['transfer-encoding'];
-  if (coding != null && !equalsIgnoreAsciiCase(coding, 'identity')) {
-    return response;
-  }
+    // We only check the last coding here because HTTP requires that the chunked
+    // encoding be listed last.
+    var coding = response.headers['transfer-encoding'];
+    if (coding != null && !equalsIgnoreAsciiCase(coding, 'identity')) {
+      return response;
+    }
 
-  return response.change(
+    return response.change(
       headers: {'transfer-encoding': 'chunked'},
-      body: chunkedCoding.encoder.bind(response.read()));
-});
+      body: chunkedCoding.encoder.bind(response.read()),
+    );
+  },
+);

--- a/pkgs/shelf/lib/src/middleware/logger.dart
+++ b/pkgs/shelf/lib/src/middleware/logger.dart
@@ -27,24 +27,38 @@ Middleware logRequests({void Function(String message, bool isError)? logger}) =>
         var startTime = DateTime.now();
         var watch = Stopwatch()..start();
 
-        return Future.sync(() => innerHandler(request)).then((response) {
-          var msg = _message(startTime, response.statusCode,
-              request.requestedUri, request.method, watch.elapsed);
+        return Future.sync(() => innerHandler(request)).then(
+          (response) {
+            var msg = _message(
+              startTime,
+              response.statusCode,
+              request.requestedUri,
+              request.method,
+              watch.elapsed,
+            );
 
-          theLogger(msg, false);
+            theLogger(msg, false);
 
-          return response;
-        }, onError: (Object error, StackTrace stackTrace) {
-          if (error is HijackException) throw error;
+            return response;
+          },
+          onError: (Object error, StackTrace stackTrace) {
+            if (error is HijackException) throw error;
 
-          var msg = _errorMessage(startTime, request.requestedUri,
-              request.method, watch.elapsed, error, stackTrace);
+            var msg = _errorMessage(
+              startTime,
+              request.requestedUri,
+              request.method,
+              watch.elapsed,
+              error,
+              stackTrace,
+            );
 
-          theLogger(msg, true);
+            theLogger(msg, true);
 
-          // ignore: only_throw_errors
-          throw error;
-        });
+            // ignore: only_throw_errors
+            throw error;
+          },
+        );
       };
     };
 
@@ -52,24 +66,36 @@ String _formatQuery(String query) {
   return query == '' ? '' : '?$query';
 }
 
-String _message(DateTime requestTime, int statusCode, Uri requestedUri,
-    String method, Duration elapsedTime) {
+String _message(
+  DateTime requestTime,
+  int statusCode,
+  Uri requestedUri,
+  String method,
+  Duration elapsedTime,
+) {
   return '${requestTime.toIso8601String()} '
       '${elapsedTime.toString().padLeft(15)} '
       '${method.padRight(7)} [$statusCode] ' // 7 - longest standard HTTP method
       '${requestedUri.path}${_formatQuery(requestedUri.query)}';
 }
 
-String _errorMessage(DateTime requestTime, Uri requestedUri, String method,
-    Duration elapsedTime, Object error, StackTrace? stack) {
+String _errorMessage(
+  DateTime requestTime,
+  Uri requestedUri,
+  String method,
+  Duration elapsedTime,
+  Object error,
+  StackTrace? stack,
+) {
   var chain = Chain.current();
   if (stack != null) {
-    chain = Chain.forTrace(stack)
-        .foldFrames((frame) => frame.isCore || frame.package == 'shelf')
-        .terse;
+    chain = Chain.forTrace(
+      stack,
+    ).foldFrames((frame) => frame.isCore || frame.package == 'shelf').terse;
   }
 
-  var msg = '$requestTime\t$elapsedTime\t$method\t${requestedUri.path}'
+  var msg =
+      '$requestTime\t$elapsedTime\t$method\t${requestedUri.path}'
       '${_formatQuery(requestedUri.query)}\n$error';
 
   return '$msg\n$chain';

--- a/pkgs/shelf/lib/src/request.dart
+++ b/pkgs/shelf/lib/src/request.dart
@@ -137,15 +137,18 @@ class Request extends Message {
     Encoding? encoding,
     Map<String, Object>? context,
     void Function(void Function(StreamChannel<List<int>>))? onHijack,
-  }) : this._(method, requestedUri,
-            protocolVersion: protocolVersion,
-            headers: headers,
-            url: url,
-            handlerPath: handlerPath,
-            body: body,
-            encoding: encoding,
-            context: context,
-            onHijack: onHijack == null ? null : _OnHijack(onHijack));
+  }) : this._(
+         method,
+         requestedUri,
+         protocolVersion: protocolVersion,
+         headers: headers,
+         url: url,
+         handlerPath: handlerPath,
+         body: body,
+         encoding: encoding,
+         context: context,
+         onHijack: onHijack == null ? null : _OnHijack(onHijack),
+       );
 
   /// This constructor has the same signature as [Request.new] except that
   /// accepts [onHijack] as [_OnHijack].
@@ -164,11 +167,11 @@ class Request extends Message {
     Encoding? encoding,
     Map<String, Object>? context,
     _OnHijack? onHijack,
-  })  : protocolVersion = protocolVersion ?? '1.1',
-        url = _computeUrl(requestedUri, handlerPath, url),
-        handlerPath = _computeHandlerPath(requestedUri, handlerPath, url),
-        _onHijack = onHijack,
-        super(body, encoding: encoding, headers: headers, context: context) {
+  }) : protocolVersion = protocolVersion ?? '1.1',
+       url = _computeUrl(requestedUri, handlerPath, url),
+       handlerPath = _computeHandlerPath(requestedUri, handlerPath, url),
+       _onHijack = onHijack,
+       super(body, encoding: encoding, headers: headers, context: context) {
     if (method.isEmpty) {
       throw ArgumentError.value(method, 'method', 'cannot be empty.');
     }
@@ -180,17 +183,26 @@ class Request extends Message {
       requestedUri.queryParametersAll;
     } on FormatException catch (e) {
       throw ArgumentError.value(
-          requestedUri, 'requestedUri', 'URI parsing failed: $e');
+        requestedUri,
+        'requestedUri',
+        'URI parsing failed: $e',
+      );
     }
 
     if (!requestedUri.isAbsolute) {
       throw ArgumentError.value(
-          requestedUri, 'requestedUri', 'must be an absolute URL.');
+        requestedUri,
+        'requestedUri',
+        'must be an absolute URL.',
+      );
     }
 
     if (requestedUri.fragment.isNotEmpty) {
       throw ArgumentError.value(
-          requestedUri, 'requestedUri', 'may not have a fragment.');
+        requestedUri,
+        'requestedUri',
+        'may not have a fragment.',
+      );
     }
 
     // Notice that because relative paths must encode colon (':') as %3A we
@@ -203,10 +215,11 @@ class Request extends Message {
     final pathSegments = '$handlerPart$join$rest';
     if (pathSegments != requestedUri.pathSegments.join('/')) {
       throw ArgumentError.value(
-          requestedUri,
-          'requestedUri',
-          'handlerPath "${this.handlerPath}" and url "${this.url}" must '
-              'combine to equal requestedUri path "${requestedUri.path}".');
+        requestedUri,
+        'requestedUri',
+        'handlerPath "${this.handlerPath}" and url "${this.url}" must '
+            'combine to equal requestedUri path "${requestedUri.path}".',
+      );
     }
   }
 
@@ -255,13 +268,16 @@ class Request extends Message {
     var handlerPath = this.handlerPath;
     if (path != null) handlerPath += path;
 
-    return Request._(method, requestedUri,
-        protocolVersion: protocolVersion,
-        headers: headersAll,
-        handlerPath: handlerPath,
-        body: body,
-        context: newContext,
-        onHijack: _onHijack);
+    return Request._(
+      method,
+      requestedUri,
+      protocolVersion: protocolVersion,
+      headers: headersAll,
+      handlerPath: handlerPath,
+      body: body,
+      context: newContext,
+      onHijack: _onHijack,
+    );
   }
 
   /// Takes control of the underlying request socket.
@@ -317,18 +333,24 @@ Uri _computeUrl(Uri requestedUri, String? handlerPath, Uri? url) {
 
   if (url != null) {
     if (url.scheme.isNotEmpty || url.hasAuthority || url.fragment.isNotEmpty) {
-      throw ArgumentError('url "$url" may contain only a path and query '
-          'parameters.');
+      throw ArgumentError(
+        'url "$url" may contain only a path and query '
+        'parameters.',
+      );
     }
 
     if (!requestedUri.path.endsWith(url.path)) {
-      throw ArgumentError('url "$url" must be a suffix of requestedUri '
-          '"$requestedUri".');
+      throw ArgumentError(
+        'url "$url" must be a suffix of requestedUri '
+        '"$requestedUri".',
+      );
     }
 
     if (requestedUri.query != url.query) {
-      throw ArgumentError('url "$url" must have the same query parameters '
-          'as requestedUri "$requestedUri".');
+      throw ArgumentError(
+        'url "$url" must have the same query parameters '
+        'as requestedUri "$requestedUri".',
+      );
     }
 
     if (url.path.startsWith('/')) {
@@ -338,15 +360,18 @@ Uri _computeUrl(Uri requestedUri, String? handlerPath, Uri? url) {
     var startOfUrl = requestedUri.path.length - url.path.length;
     if (url.path.isNotEmpty &&
         requestedUri.path.substring(startOfUrl - 1, startOfUrl) != '/') {
-      throw ArgumentError('url "$url" must be on a path boundary in '
-          'requestedUri "$requestedUri".');
+      throw ArgumentError(
+        'url "$url" must be on a path boundary in '
+        'requestedUri "$requestedUri".',
+      );
     }
 
     return url;
   } else if (handlerPath != null) {
     return Uri(
-        path: requestedUri.path.substring(handlerPath.length),
-        query: requestedUri.query);
+      path: requestedUri.path.substring(handlerPath.length),
+      query: requestedUri.query,
+    );
   } else {
     // Skip the initial "/".
     var path = requestedUri.path.substring(1);
@@ -367,8 +392,10 @@ String _computeHandlerPath(Uri requestedUri, String? handlerPath, Uri? url) {
 
   if (handlerPath != null) {
     if (!requestedUri.path.startsWith(handlerPath)) {
-      throw ArgumentError('handlerPath "$handlerPath" must be a prefix of '
-          'requestedUri path "${requestedUri.path}"');
+      throw ArgumentError(
+        'handlerPath "$handlerPath" must be a prefix of '
+        'requestedUri path "${requestedUri.path}"',
+      );
     }
 
     if (!handlerPath.startsWith('/')) {

--- a/pkgs/shelf/lib/src/response.dart
+++ b/pkgs/shelf/lib/src/response.dart
@@ -69,8 +69,13 @@ class Response extends Message {
     Map<String, /* String | List<String> */ Object>? headers,
     Encoding? encoding,
     Map<String, Object>? context,
-  }) : this(200,
-            body: body, headers: headers, encoding: encoding, context: context);
+  }) : this(
+         200,
+         body: body,
+         headers: headers,
+         encoding: encoding,
+         context: context,
+       );
 
   /// Constructs a 301 Moved Permanently response.
   ///
@@ -100,14 +105,7 @@ class Response extends Message {
     Map<String, /* String | List<String> */ Object>? headers,
     Encoding? encoding,
     Map<String, Object>? context,
-  }) : this._redirect(
-          302,
-          location,
-          body,
-          headers,
-          encoding,
-          context: context,
-        );
+  }) : this._redirect(302, location, body, headers, encoding, context: context);
 
   /// Constructs a 303 See Other response.
   ///
@@ -134,12 +132,12 @@ class Response extends Message {
     Encoding? encoding, {
     Map<String, Object>? context,
   }) : this(
-          statusCode,
-          body: body,
-          encoding: encoding,
-          headers: addHeader(headers, 'location', _locationToString(location)),
-          context: context,
-        );
+         statusCode,
+         body: body,
+         encoding: encoding,
+         headers: addHeader(headers, 'location', _locationToString(location)),
+         context: context,
+       );
 
   /// Constructs a 304 Not Modified response.
   ///
@@ -156,12 +154,13 @@ class Response extends Message {
     Map<String, /* String | List<String> */ Object>? headers,
     Map<String, Object>? context,
   }) : this(
-          304,
-          headers: removeHeader(
-              addHeader(headers, 'date', formatHttpDate(DateTime.now())),
-              'content-length'),
-          context: context,
-        );
+         304,
+         headers: removeHeader(
+           addHeader(headers, 'date', formatHttpDate(DateTime.now())),
+           'content-length',
+         ),
+         context: context,
+       );
 
   /// Constructs a 400 Bad Request response.
   ///
@@ -174,12 +173,12 @@ class Response extends Message {
     Encoding? encoding,
     Map<String, Object>? context,
   }) : this(
-          400,
-          headers: body == null ? _adjustErrorHeaders(headers) : headers,
-          body: body ?? 'Bad Request',
-          context: context,
-          encoding: encoding,
-        );
+         400,
+         headers: body == null ? _adjustErrorHeaders(headers) : headers,
+         body: body ?? 'Bad Request',
+         context: context,
+         encoding: encoding,
+       );
 
   /// Constructs a 401 Unauthorized response.
   ///
@@ -193,12 +192,12 @@ class Response extends Message {
     Encoding? encoding,
     Map<String, Object>? context,
   }) : this(
-          401,
-          headers: body == null ? _adjustErrorHeaders(headers) : headers,
-          body: body ?? 'Unauthorized',
-          context: context,
-          encoding: encoding,
-        );
+         401,
+         headers: body == null ? _adjustErrorHeaders(headers) : headers,
+         body: body ?? 'Unauthorized',
+         context: context,
+         encoding: encoding,
+       );
 
   /// Constructs a 403 Forbidden response.
   ///
@@ -211,12 +210,12 @@ class Response extends Message {
     Encoding? encoding,
     Map<String, Object>? context,
   }) : this(
-          403,
-          headers: body == null ? _adjustErrorHeaders(headers) : headers,
-          body: body ?? 'Forbidden',
-          context: context,
-          encoding: encoding,
-        );
+         403,
+         headers: body == null ? _adjustErrorHeaders(headers) : headers,
+         body: body ?? 'Forbidden',
+         context: context,
+         encoding: encoding,
+       );
 
   /// Constructs a 404 Not Found response.
   ///
@@ -230,12 +229,12 @@ class Response extends Message {
     Encoding? encoding,
     Map<String, Object>? context,
   }) : this(
-          404,
-          headers: body == null ? _adjustErrorHeaders(headers) : headers,
-          body: body ?? 'Not Found',
-          context: context,
-          encoding: encoding,
-        );
+         404,
+         headers: body == null ? _adjustErrorHeaders(headers) : headers,
+         body: body ?? 'Not Found',
+         context: context,
+         encoding: encoding,
+       );
 
   /// Constructs a 500 Internal Server Error response.
   ///
@@ -249,12 +248,12 @@ class Response extends Message {
     Encoding? encoding,
     Map<String, Object>? context,
   }) : this(
-          500,
-          headers: body == null ? _adjustErrorHeaders(headers) : headers,
-          body: body ?? 'Internal Server Error',
-          context: context,
-          encoding: encoding,
-        );
+         500,
+         headers: body == null ? _adjustErrorHeaders(headers) : headers,
+         body: body ?? 'Internal Server Error',
+         context: context,
+         encoding: encoding,
+       );
 
   /// Constructs an HTTP response with the given [statusCode].
   ///
@@ -317,15 +316,18 @@ class Response extends Message {
 /// Returns a new map without modifying [headers]. This is used to add
 /// content-type information when creating a 500 response with a default body.
 Map<String, Object> _adjustErrorHeaders(
-    Map<String, /* String | List<String> */ Object>? headers) {
+  Map<String, /* String | List<String> */ Object>? headers,
+) {
   if (headers == null || headers['content-type'] == null) {
     return addHeader(headers, 'content-type', 'text/plain');
   }
 
-  final contentTypeValue =
-      expandHeaderValue(headers['content-type']!).join(',');
-  var contentType =
-      MediaType.parse(contentTypeValue).change(mimeType: 'text/plain');
+  final contentTypeValue = expandHeaderValue(
+    headers['content-type']!,
+  ).join(',');
+  var contentType = MediaType.parse(
+    contentTypeValue,
+  ).change(mimeType: 'text/plain');
   return addHeader(headers, 'content-type', contentType.toString());
 }
 

--- a/pkgs/shelf/lib/src/server_handler.dart
+++ b/pkgs/shelf/lib/src/server_handler.dart
@@ -16,8 +16,10 @@ import 'server.dart';
 /// Requests to the handler are sent to the server's mounted handler once it's
 /// available. This is used to expose a virtual [Server] that's actually one
 /// part of a larger URL-space.
-@Deprecated('Do not use. If you have a use case for this class add a comment '
-    'at https://github.com/dart-lang/shelf/issues/205')
+@Deprecated(
+  'Do not use. If you have a use case for this class add a comment '
+  'at https://github.com/dart-lang/shelf/issues/205',
+)
 class ServerHandler {
   /// The server.
   ///
@@ -41,7 +43,7 @@ class ServerHandler {
   /// If [onClose] is passed, it's called when [server] is closed. It may return
   /// a [Future] or `null`; its return value is returned by [Server.close].
   ServerHandler(Uri url, {Future<void>? Function()? onClose})
-      : _server = _HandlerServer(url, onClose);
+    : _server = _HandlerServer(url, onClose);
 
   /// Pipes requests to [server]'s handler.
   FutureOr<Response> _onRequest(Request request) {
@@ -89,7 +91,7 @@ class _HandlerServer implements Server {
 
   @override
   Future<void> close() => _closeMemo.runOnce(() {
-        return _onClose == null ? null : _onClose();
-      });
+    return _onClose == null ? null : _onClose();
+  });
   final _closeMemo = AsyncMemoizer<void>();
 }

--- a/pkgs/shelf/lib/src/util.dart
+++ b/pkgs/shelf/lib/src/util.dart
@@ -13,8 +13,10 @@ import 'shelf_unmodifiable_map.dart';
 /// If `this` is called in a non-root error zone, it will just run [callback]
 /// and return the result. Otherwise, it will capture any errors using
 /// [runZoned] and pass them to [onError].
-void catchTopLevelErrors(void Function() callback,
-    void Function(dynamic error, StackTrace) onError) {
+void catchTopLevelErrors(
+  void Function() callback,
+  void Function(dynamic error, StackTrace) onError,
+) {
   if (Zone.current.inSameErrorZone(Zone.root)) {
     return runZonedGuarded(callback, onError);
   } else {
@@ -61,10 +63,7 @@ Map<String, Object> addHeader(
 /// Removed the header with case-insensitive name [name].
 ///
 /// Returns a new map without modifying [headers].
-Map<String, Object> removeHeader(
-  Map<String, Object>? headers,
-  String name,
-) {
+Map<String, Object> removeHeader(Map<String, Object>? headers, String name) {
   headers = headers == null ? {} : Map.from(headers);
   headers.removeWhere((header, value) => equalsIgnoreAsciiCase(header, name));
   return headers;
@@ -104,10 +103,12 @@ Map<String, List<String>?>? _expandToHeadersAll(
   if (headers is Map<String, List<String>>) return headers;
   if (headers == null || headers.isEmpty) return null;
 
-  return Map.fromEntries(headers.entries.map((e) {
-    final val = e.value;
-    return MapEntry(e.key, val == null ? null : expandHeaderValue(val));
-  }));
+  return Map.fromEntries(
+    headers.entries.map((e) {
+      final val = e.value;
+      return MapEntry(e.key, val == null ? null : expandHeaderValue(val));
+    }),
+  );
 }
 
 Map<String, List<String>>? expandToHeadersAll(
@@ -116,9 +117,11 @@ Map<String, List<String>>? expandToHeadersAll(
   if (headers is Map<String, List<String>>) return headers;
   if (headers == null || headers.isEmpty) return null;
 
-  return Map.fromEntries(headers.entries.map((e) {
-    return MapEntry(e.key, expandHeaderValue(e.value));
-  }));
+  return Map.fromEntries(
+    headers.entries.map((e) {
+      return MapEntry(e.key, expandHeaderValue(e.value));
+    }),
+  );
 }
 
 List<String> expandHeaderValue(Object v) {

--- a/pkgs/shelf/pubspec.yaml
+++ b/pkgs/shelf/pubspec.yaml
@@ -11,7 +11,7 @@ topics:
   - backend
 
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.9.0
 
 dependencies:
   async: ^2.5.0

--- a/pkgs/shelf/test/add_chunked_encoding_test.dart
+++ b/pkgs/shelf/test/add_chunked_encoding_test.dart
@@ -10,15 +10,19 @@ import 'package:test/test.dart';
 void main() {
   test('adds chunked encoding with no transfer-encoding header', () async {
     var response = await _chunkResponse(
-        Response.ok(Stream.fromIterable(['hi'.codeUnits])));
+      Response.ok(Stream.fromIterable(['hi'.codeUnits])),
+    );
     expect(response.headers, containsPair('transfer-encoding', 'chunked'));
     expect(response.readAsString(), completion(equals('2\r\nhi\r\n0\r\n\r\n')));
   });
 
   test('adds chunked encoding with transfer-encoding: identity', () async {
-    var response = await _chunkResponse(Response.ok(
+    var response = await _chunkResponse(
+      Response.ok(
         Stream.fromIterable(['hi'.codeUnits]),
-        headers: {'transfer-encoding': 'identity'}));
+        headers: {'transfer-encoding': 'identity'},
+      ),
+    );
     expect(response.headers, containsPair('transfer-encoding', 'chunked'));
     expect(response.readAsString(), completion(equals('2\r\nhi\r\n0\r\n\r\n')));
   });
@@ -31,41 +35,45 @@ void main() {
 
   test("doesn't add chunked encoding with status 1xx", () async {
     var response = await _chunkResponse(
-        Response(123, body: const Stream<List<int>>.empty()));
+      Response(123, body: const Stream<List<int>>.empty()),
+    );
     expect(response.headers, isNot(contains('transfer-encoding')));
     expect(response.read().toList(), completion(isEmpty));
   });
 
   test("doesn't add chunked encoding with status 204", () async {
     var response = await _chunkResponse(
-        Response(204, body: const Stream<List<int>>.empty()));
+      Response(204, body: const Stream<List<int>>.empty()),
+    );
     expect(response.headers, isNot(contains('transfer-encoding')));
     expect(response.read().toList(), completion(isEmpty));
   });
 
   test("doesn't add chunked encoding with status 304", () async {
     var response = await _chunkResponse(
-        Response(204, body: const Stream<List<int>>.empty()));
+      Response(204, body: const Stream<List<int>>.empty()),
+    );
     expect(response.headers, isNot(contains('transfer-encoding')));
     expect(response.read().toList(), completion(isEmpty));
   });
 
   test("doesn't add chunked encoding with status 204", () async {
     var response = await _chunkResponse(
-        Response(204, body: const Stream<List<int>>.empty()));
+      Response(204, body: const Stream<List<int>>.empty()),
+    );
     expect(response.headers, isNot(contains('transfer-encoding')));
     expect(response.read().toList(), completion(isEmpty));
   });
 
   test("doesn't add chunked encoding with status 204", () async {
     var response = await _chunkResponse(
-        Response(204, body: const Stream<List<int>>.empty()));
+      Response(204, body: const Stream<List<int>>.empty()),
+    );
     expect(response.headers, isNot(contains('transfer-encoding')));
     expect(response.read().toList(), completion(isEmpty));
   });
 }
 
-FutureOr<Response> _chunkResponse(Response response) =>
-    addChunkedEncoding((_) => response)(
-      Request('GET', Uri.parse('http://example.com/')),
-    );
+FutureOr<Response> _chunkResponse(Response response) => addChunkedEncoding(
+  (_) => response,
+)(Request('GET', Uri.parse('http://example.com/')));

--- a/pkgs/shelf/test/cascade_test.dart
+++ b/pkgs/shelf/test/cascade_test.dart
@@ -11,25 +11,29 @@ void main() {
   group('a cascade with several handlers', () {
     late Handler handler;
     setUp(() {
-      handler = Cascade().add((request) {
-        if (request.headers['one'] == 'false') {
-          return Response.notFound('handler 1');
-        } else {
-          return Response.ok('handler 1');
-        }
-      }).add((request) {
-        if (request.headers['two'] == 'false') {
-          return Response.notFound('handler 2');
-        } else {
-          return Response.ok('handler 2');
-        }
-      }).add((request) {
-        if (request.headers['three'] == 'false') {
-          return Response.notFound('handler 3');
-        } else {
-          return Response.ok('handler 3');
-        }
-      }).handler;
+      handler = Cascade()
+          .add((request) {
+            if (request.headers['one'] == 'false') {
+              return Response.notFound('handler 1');
+            } else {
+              return Response.ok('handler 1');
+            }
+          })
+          .add((request) {
+            if (request.headers['two'] == 'false') {
+              return Response.notFound('handler 2');
+            } else {
+              return Response.ok('handler 2');
+            }
+          })
+          .add((request) {
+            if (request.headers['three'] == 'false') {
+              return Response.notFound('handler 3');
+            } else {
+              return Response.ok('handler 3');
+            }
+          })
+          .handler;
     });
 
     test('the first response should be returned if it matches', () async {
@@ -38,8 +42,7 @@ void main() {
       expect(response.readAsString(), completion(equals('handler 1')));
     });
 
-    test(
-        'the second response should be returned if it matches and the first '
+    test('the second response should be returned if it matches and the first '
         "doesn't", () async {
       final response = await handler(
         Request('GET', localhostUri, headers: {'one': 'false'}),
@@ -48,8 +51,7 @@ void main() {
       expect(response.readAsString(), completion(equals('handler 2')));
     });
 
-    test(
-        'the third response should be returned if it matches and the first '
+    test('the third response should be returned if it matches and the first '
         "two don't", () async {
       final response = await handler(
         Request('GET', localhostUri, headers: {'one': 'false', 'two': 'false'}),
@@ -59,18 +61,20 @@ void main() {
       expect(response.readAsString(), completion(equals('handler 3')));
     });
 
-    test('the third response should be returned if no response matches',
-        () async {
-      final response = await handler(
-        Request(
-          'GET',
-          localhostUri,
-          headers: {'one': 'false', 'two': 'false', 'three': 'false'},
-        ),
-      );
-      expect(response.statusCode, equals(404));
-      expect(response.readAsString(), completion(equals('handler 3')));
-    });
+    test(
+      'the third response should be returned if no response matches',
+      () async {
+        final response = await handler(
+          Request(
+            'GET',
+            localhostUri,
+            headers: {'one': 'false', 'two': 'false', 'three': 'false'},
+          ),
+        );
+        expect(response.statusCode, equals(404));
+        expect(response.readAsString(), completion(equals('handler 3')));
+      },
+    );
   });
 
   test('a 404 response triggers a cascade by default', () async {
@@ -127,11 +131,14 @@ void main() {
       expect(() => Cascade().handler, throwsStateError);
     });
 
-    test('passing [statusCodes] and [shouldCascade] at the same time fails',
-        () {
-      expect(
+    test(
+      'passing [statusCodes] and [shouldCascade] at the same time fails',
+      () {
+        expect(
           () => Cascade(statusCodes: [404, 405], shouldCascade: (_) => false),
-          throwsArgumentError);
-    });
+          throwsArgumentError,
+        );
+      },
+    );
   });
 }

--- a/pkgs/shelf/test/create_middleware_test.dart
+++ b/pkgs/shelf/test/create_middleware_test.dart
@@ -13,11 +13,11 @@ import 'test_util.dart';
 
 void main() {
   test('forwards the request and response if both handlers are null', () async {
-    var handler = const Pipeline()
-        .addMiddleware(createMiddleware())
-        .addHandler((request) {
-      return syncHandler(request, headers: {'from': 'innerHandler'});
-    });
+    var handler = const Pipeline().addMiddleware(createMiddleware()).addHandler(
+      (request) {
+        return syncHandler(request, headers: {'from': 'innerHandler'});
+      },
+    );
 
     final response = await makeSimpleRequest(handler);
     expect(response.headers['from'], 'innerHandler');
@@ -36,7 +36,8 @@ void main() {
     test('async null response forwards to inner handler', () async {
       var handler = const Pipeline()
           .addMiddleware(
-              createMiddleware(requestHandler: (request) => Future.value(null)))
+            createMiddleware(requestHandler: (request) => Future.value(null)),
+          )
           .addHandler(syncHandler);
 
       final response = await makeSimpleRequest(handler);
@@ -45,8 +46,9 @@ void main() {
 
     test('sync response is returned', () async {
       var handler = const Pipeline()
-          .addMiddleware(createMiddleware(
-              requestHandler: (request) => _middlewareResponse))
+          .addMiddleware(
+            createMiddleware(requestHandler: (request) => _middlewareResponse),
+          )
           .addHandler(_failHandler);
 
       final response = await makeSimpleRequest(handler);
@@ -55,8 +57,11 @@ void main() {
 
     test('async response is returned', () async {
       var handler = const Pipeline()
-          .addMiddleware(createMiddleware(
-              requestHandler: (request) => Future.value(_middlewareResponse)))
+          .addMiddleware(
+            createMiddleware(
+              requestHandler: (request) => Future.value(_middlewareResponse),
+            ),
+          )
           .addHandler(_failHandler);
 
       final response = await makeSimpleRequest(handler);
@@ -66,11 +71,13 @@ void main() {
     group('with responseHandler', () {
       test('with sync result, responseHandler is not called', () async {
         var middleware = createMiddleware(
-            requestHandler: (request) => _middlewareResponse,
-            responseHandler: (response) => fail('should not be called'));
+          requestHandler: (request) => _middlewareResponse,
+          responseHandler: (response) => fail('should not be called'),
+        );
 
-        var handler =
-            const Pipeline().addMiddleware(middleware).addHandler(syncHandler);
+        var handler = const Pipeline()
+            .addMiddleware(middleware)
+            .addHandler(syncHandler);
 
         final response = await makeSimpleRequest(handler);
         expect(response.headers['from'], 'middleware');
@@ -78,10 +85,12 @@ void main() {
 
       test('with async result, responseHandler is not called', () async {
         var middleware = createMiddleware(
-            requestHandler: (request) => Future.value(_middlewareResponse),
-            responseHandler: (response) => fail('should not be called'));
-        var handler =
-            const Pipeline().addMiddleware(middleware).addHandler(syncHandler);
+          requestHandler: (request) => Future.value(_middlewareResponse),
+          responseHandler: (response) => fail('should not be called'),
+        );
+        var handler = const Pipeline()
+            .addMiddleware(middleware)
+            .addHandler(syncHandler);
 
         final response = await makeSimpleRequest(handler);
         expect(response.headers['from'], 'middleware');
@@ -90,40 +99,59 @@ void main() {
   });
 
   group('responseHandler', () {
-    test('innerHandler sync response is seen, replaced value continues',
-        () async {
-      var handler = const Pipeline()
-          .addMiddleware(createMiddleware(responseHandler: (response) {
-        expect(response.headers['from'], 'handler');
-        return _middlewareResponse;
-      })).addHandler((request) {
-        return syncHandler(request, headers: {'from': 'handler'});
-      });
+    test(
+      'innerHandler sync response is seen, replaced value continues',
+      () async {
+        var handler = const Pipeline()
+            .addMiddleware(
+              createMiddleware(
+                responseHandler: (response) {
+                  expect(response.headers['from'], 'handler');
+                  return _middlewareResponse;
+                },
+              ),
+            )
+            .addHandler((request) {
+              return syncHandler(request, headers: {'from': 'handler'});
+            });
 
-      final response = await makeSimpleRequest(handler);
-      expect(response.headers['from'], 'middleware');
-    });
+        final response = await makeSimpleRequest(handler);
+        expect(response.headers['from'], 'middleware');
+      },
+    );
 
-    test('innerHandler async response is seen, async value continues',
-        () async {
-      var handler = const Pipeline()
-          .addMiddleware(createMiddleware(responseHandler: (response) {
-        expect(response.headers['from'], 'handler');
-        return Future.value(_middlewareResponse);
-      })).addHandler((request) {
-        return Future(() => syncHandler(request, headers: {'from': 'handler'}));
-      });
+    test(
+      'innerHandler async response is seen, async value continues',
+      () async {
+        var handler = const Pipeline()
+            .addMiddleware(
+              createMiddleware(
+                responseHandler: (response) {
+                  expect(response.headers['from'], 'handler');
+                  return Future.value(_middlewareResponse);
+                },
+              ),
+            )
+            .addHandler((request) {
+              return Future(
+                () => syncHandler(request, headers: {'from': 'handler'}),
+              );
+            });
 
-      final response = await makeSimpleRequest(handler);
-      expect(response.headers['from'], 'middleware');
-    });
+        final response = await makeSimpleRequest(handler);
+        expect(response.headers['from'], 'middleware');
+      },
+    );
   });
 
   group('error handling', () {
     test('sync error thrown by requestHandler bubbles down', () {
       var handler = const Pipeline()
-          .addMiddleware(createMiddleware(
-              requestHandler: (request) => throw 'middleware error'))
+          .addMiddleware(
+            createMiddleware(
+              requestHandler: (request) => throw 'middleware error',
+            ),
+          )
           .addHandler(_failHandler);
 
       expect(makeSimpleRequest(handler), throwsA('middleware error'));
@@ -131,8 +159,11 @@ void main() {
 
     test('async error thrown by requestHandler bubbles down', () {
       var handler = const Pipeline()
-          .addMiddleware(createMiddleware(
-              requestHandler: (request) => Future.error('middleware error')))
+          .addMiddleware(
+            createMiddleware(
+              requestHandler: (request) => Future.error('middleware error'),
+            ),
+          )
           .addHandler(_failHandler);
 
       expect(makeSimpleRequest(handler), throwsA('middleware error'));
@@ -140,67 +171,79 @@ void main() {
 
     test('throw from responseHandler does not hit error handler', () {
       var middleware = createMiddleware(
-          responseHandler: (response) {
-            throw 'middleware error';
-          },
-          errorHandler: (e, s) => fail('should never get here'));
+        responseHandler: (response) {
+          throw 'middleware error';
+        },
+        errorHandler: (e, s) => fail('should never get here'),
+      );
 
-      var handler =
-          const Pipeline().addMiddleware(middleware).addHandler(syncHandler);
+      var handler = const Pipeline()
+          .addMiddleware(middleware)
+          .addHandler(syncHandler);
 
       expect(makeSimpleRequest(handler), throwsA('middleware error'));
     });
 
     test('requestHandler throw does not hit errorHandlers', () {
       var middleware = createMiddleware(
-          requestHandler: (request) {
-            throw 'middleware error';
-          },
-          errorHandler: (e, s) => fail('should never get here'));
+        requestHandler: (request) {
+          throw 'middleware error';
+        },
+        errorHandler: (e, s) => fail('should never get here'),
+      );
 
-      var handler =
-          const Pipeline().addMiddleware(middleware).addHandler(syncHandler);
+      var handler = const Pipeline()
+          .addMiddleware(middleware)
+          .addHandler(syncHandler);
 
       expect(makeSimpleRequest(handler), throwsA('middleware error'));
     });
 
-    test('inner handler throws, is caught by errorHandler with response',
-        () async {
-      var middleware = createMiddleware(errorHandler: (error, stack) {
-        expect(error, 'bad handler');
-        return _middlewareResponse;
-      });
+    test(
+      'inner handler throws, is caught by errorHandler with response',
+      () async {
+        var middleware = createMiddleware(
+          errorHandler: (error, stack) {
+            expect(error, 'bad handler');
+            return _middlewareResponse;
+          },
+        );
 
-      var handler =
-          const Pipeline().addMiddleware(middleware).addHandler((request) {
-        throw 'bad handler';
-      });
+        var handler = const Pipeline().addMiddleware(middleware).addHandler((
+          request,
+        ) {
+          throw 'bad handler';
+        });
 
-      final response = await makeSimpleRequest(handler);
-      expect(response.headers['from'], 'middleware');
-    });
+        final response = await makeSimpleRequest(handler);
+        expect(response.headers['from'], 'middleware');
+      },
+    );
 
     test('inner handler throws, is caught by errorHandler and rethrown', () {
-      var middleware = createMiddleware(errorHandler: (Object error, stack) {
-        expect(error, 'bad handler');
-        throw error;
-      });
+      var middleware = createMiddleware(
+        errorHandler: (Object error, stack) {
+          expect(error, 'bad handler');
+          throw error;
+        },
+      );
 
-      var handler =
-          const Pipeline().addMiddleware(middleware).addHandler((request) {
+      var handler = const Pipeline().addMiddleware(middleware).addHandler((
+        request,
+      ) {
         throw 'bad handler';
       });
 
       expect(makeSimpleRequest(handler), throwsA('bad handler'));
     });
 
-    test(
-        'error thrown by inner handler without a middleware errorHandler is '
+    test('error thrown by inner handler without a middleware errorHandler is '
         'rethrown', () {
       var middleware = createMiddleware();
 
-      var handler =
-          const Pipeline().addMiddleware(middleware).addHandler((request) {
+      var handler = const Pipeline().addMiddleware(middleware).addHandler((
+        request,
+      ) {
         throw 'bad handler';
       });
 
@@ -208,9 +251,11 @@ void main() {
     });
 
     test("doesn't handle HijackException", () {
-      var middleware = createMiddleware(errorHandler: (error, stack) {
-        fail("error handler shouldn't be called");
-      });
+      var middleware = createMiddleware(
+        errorHandler: (error, stack) {
+          fail("error handler shouldn't be called");
+        },
+      );
 
       var handler = const Pipeline()
           .addMiddleware(middleware)
@@ -223,5 +268,7 @@ void main() {
 
 Response _failHandler(Request request) => fail('should never get here');
 
-final Response _middlewareResponse =
-    Response.ok('middleware content', headers: {'from': 'middleware'});
+final Response _middlewareResponse = Response.ok(
+  'middleware content',
+  headers: {'from': 'middleware'},
+);

--- a/pkgs/shelf/test/headers_test.dart
+++ b/pkgs/shelf/test/headers_test.dart
@@ -15,10 +15,12 @@ void main() {
   });
 
   test('Headers.fromEntries', () {
-    var header = Headers.fromEntries({
-      'FoO': ['x', 'y'],
-      'bAr': ['z'],
-    }.entries);
+    var header = Headers.fromEntries(
+      {
+        'FoO': ['x', 'y'],
+        'bAr': ['z'],
+      }.entries,
+    );
 
     expect(header['foo'], equals(['x', 'y']));
     expect(header['BAR'], equals(['z']));

--- a/pkgs/shelf/test/hijack_test.dart
+++ b/pkgs/shelf/test/hijack_test.dart
@@ -15,34 +15,42 @@ void main() {
     expect(() => Request('GET', localhostUri).hijack((_) {}), throwsStateError);
   });
 
-  test(
-      'hijacking a hijackable request throws a HijackException and calls '
+  test('hijacking a hijackable request throws a HijackException and calls '
       'onHijack', () {
-    var request =
-        Request('GET', localhostUri, onHijack: expectAsync1((callback) {
-      var streamController = StreamController<List<int>>();
-      streamController.add([1, 2, 3]);
-      streamController.close();
+    var request = Request(
+      'GET',
+      localhostUri,
+      onHijack: expectAsync1((callback) {
+        var streamController = StreamController<List<int>>();
+        streamController.add([1, 2, 3]);
+        streamController.close();
 
-      var sinkController = StreamController<List<int>>();
-      expect(sinkController.stream.first, completion(equals([4, 5, 6])));
+        var sinkController = StreamController<List<int>>();
+        expect(sinkController.stream.first, completion(equals([4, 5, 6])));
 
-      callback(StreamChannel(streamController.stream, sinkController));
-    }));
+        callback(StreamChannel(streamController.stream, sinkController));
+      }),
+    );
 
     expect(
-        () => request.hijack(expectAsync1((channel) {
-              expect(channel.stream.first, completion(equals([1, 2, 3])));
-              channel.sink.add([4, 5, 6]);
-              channel.sink.close();
-            })),
-        throwsHijackException);
+      () => request.hijack(
+        expectAsync1((channel) {
+          expect(channel.stream.first, completion(equals([1, 2, 3])));
+          channel.sink.add([4, 5, 6]);
+          channel.sink.close();
+        }),
+      ),
+      throwsHijackException,
+    );
   });
 
   test('hijacking a hijackable request twice throws a StateError', () {
     // Assert that the [onHijack] callback is only called once.
-    var request =
-        Request('GET', localhostUri, onHijack: expectAsync1((_) {}, count: 1));
+    var request = Request(
+      'GET',
+      localhostUri,
+      onHijack: expectAsync1((_) {}, count: 1),
+    );
 
     expect(() => request.hijack((_) {}), throwsHijackException);
 
@@ -56,38 +64,45 @@ void main() {
       expect(() => newRequest.hijack((_) {}), throwsStateError);
     });
 
-    test(
-        'hijacking a hijackable request throws a HijackException and calls '
+    test('hijacking a hijackable request throws a HijackException and calls '
         'onHijack', () {
-      var request =
-          Request('GET', localhostUri, onHijack: expectAsync1((callback) {
-        var streamController = StreamController<List<int>>();
-        streamController.add([1, 2, 3]);
-        streamController.close();
+      var request = Request(
+        'GET',
+        localhostUri,
+        onHijack: expectAsync1((callback) {
+          var streamController = StreamController<List<int>>();
+          streamController.add([1, 2, 3]);
+          streamController.close();
 
-        var sinkController = StreamController<List<int>>();
-        expect(sinkController.stream.first, completion(equals([4, 5, 6])));
+          var sinkController = StreamController<List<int>>();
+          expect(sinkController.stream.first, completion(equals([4, 5, 6])));
 
-        callback(StreamChannel(streamController.stream, sinkController));
-      }));
+          callback(StreamChannel(streamController.stream, sinkController));
+        }),
+      );
 
       var newRequest = request.change();
 
       expect(
-          () => newRequest.hijack(expectAsync1((channel) {
-                expect(channel.stream.first, completion(equals([1, 2, 3])));
-                channel.sink.add([4, 5, 6]);
-                channel.sink.close();
-              })),
-          throwsHijackException);
+        () => newRequest.hijack(
+          expectAsync1((channel) {
+            expect(channel.stream.first, completion(equals([1, 2, 3])));
+            channel.sink.add([4, 5, 6]);
+            channel.sink.close();
+          }),
+        ),
+        throwsHijackException,
+      );
     });
 
-    test(
-        'hijacking the original request after calling change throws a '
+    test('hijacking the original request after calling change throws a '
         'StateError', () {
       // Assert that the [onHijack] callback is only called once.
-      var request = Request('GET', localhostUri,
-          onHijack: expectAsync1((_) {}, count: 1));
+      var request = Request(
+        'GET',
+        localhostUri,
+        onHijack: expectAsync1((_) {}, count: 1),
+      );
 
       var newRequest = request.change();
 

--- a/pkgs/shelf/test/io_server_test.dart
+++ b/pkgs/shelf/test/io_server_test.dart
@@ -34,8 +34,9 @@ void main() {
 
   test('Handles malformed requests gracefully.', () async {
     server.mount(syncHandler);
-    final rs = await http
-        .get(Uri.parse('${server.url}/%D0%C2%BD%A8%CE%C4%BC%FE%BC%D0.zip'));
+    final rs = await http.get(
+      Uri.parse('${server.url}/%D0%C2%BD%A8%CE%C4%BC%FE%BC%D0.zip'),
+    );
     expect(rs.statusCode, 400);
     expect(rs.body, 'Bad Request');
   });

--- a/pkgs/shelf/test/log_middleware_test.dart
+++ b/pkgs/shelf/test/log_middleware_test.dart
@@ -41,16 +41,21 @@ void main() {
   });
 
   test('logs a request with an asynchronous error response', () {
-    var handler =
-        const Pipeline().addMiddleware(logRequests(logger: (msg, isError) {
-      expect(gotLog, isFalse);
-      gotLog = true;
-      expect(isError, isTrue);
-      expect(msg, contains('\tGET\t/'));
-      expect(msg, contains('oh no'));
-    })).addHandler((request) {
-      throw StateError('oh no');
-    });
+    var handler = const Pipeline()
+        .addMiddleware(
+          logRequests(
+            logger: (msg, isError) {
+              expect(gotLog, isFalse);
+              gotLog = true;
+              expect(isError, isTrue);
+              expect(msg, contains('\tGET\t/'));
+              expect(msg, contains('oh no'));
+            },
+          ),
+        )
+        .addHandler((request) {
+          throw StateError('oh no');
+        });
 
     expect(makeSimpleRequest(handler), throwsA(isOhNoStateError));
   });
@@ -61,9 +66,10 @@ void main() {
         .addHandler((request) => throw const HijackException());
 
     expect(
-        makeSimpleRequest(handler).whenComplete(() {
-          expect(gotLog, isFalse);
-        }),
-        throwsHijackException);
+      makeSimpleRequest(handler).whenComplete(() {
+        expect(gotLog, isFalse);
+      }),
+      throwsHijackException,
+    );
   });
 }

--- a/pkgs/shelf/test/message_change_test.dart
+++ b/pkgs/shelf/test/message_change_test.dart
@@ -34,11 +34,7 @@ void main() {
       Map<String, Object>? headers,
       Map<String, Object>? context,
     }) {
-      return Response.ok(
-        body,
-        headers: headers,
-        context: context,
-      );
+      return Response.ok(body, headers: headers, context: context);
     });
   });
 }
@@ -46,11 +42,13 @@ void main() {
 /// Shared test method used by [Request] and [Response] tests to validate
 /// the behavior of `change` with different `headers` and `context` values.
 void _testChange(
-    Message Function({
-      dynamic body,
-      Map<String, String> headers,
-      Map<String, Object> context,
-    }) factory) {
+  Message Function({
+    dynamic body,
+    Map<String, String> headers,
+    Map<String, Object> context,
+  })
+  factory,
+) {
   group('body', () {
     test('with String', () async {
       var request = factory(body: 'Hello, world');
@@ -64,8 +62,8 @@ void _testChange(
     test('with Stream', () async {
       var request = factory(body: 'Hello, world');
       var copy = request.change(
-          body:
-              Stream.fromIterable(['Goodbye, world']).transform(utf8.encoder));
+        body: Stream.fromIterable(['Goodbye, world']).transform(utf8.encoder),
+      );
 
       var newBody = await copy.readAsString();
 
@@ -92,8 +90,11 @@ void _testChange(
     var request = factory(headers: {'test': 'test value'});
     var copy = request.change(headers: {'test2': 'test2 value'});
 
-    expect(copy.headers,
-        {'test': 'test value', 'test2': 'test2 value', 'content-length': '0'});
+    expect(copy.headers, {
+      'test': 'test value',
+      'test2': 'test2 value',
+      'content-length': '0',
+    });
   });
 
   test('existing header values are overwritten', () {

--- a/pkgs/shelf/test/message_test.dart
+++ b/pkgs/shelf/test/message_test.dart
@@ -11,24 +11,29 @@ import 'package:test/test.dart';
 import 'test_util.dart';
 
 class _TestMessage extends Message {
-  _TestMessage(Map<String, /* String | List<String> */ Object>? headers,
-      Map<String, Object>? context, super.body, Encoding? encoding)
-      : super(headers: headers, context: context, encoding: encoding);
+  _TestMessage(
+    Map<String, /* String | List<String> */ Object>? headers,
+    Map<String, Object>? context,
+    super.body,
+    Encoding? encoding,
+  ) : super(headers: headers, context: context, encoding: encoding);
 
   @override
-  Message change(
-      {Map<String, String>? headers,
-      Map<String, Object>? context,
-      Object? body}) {
+  Message change({
+    Map<String, String>? headers,
+    Map<String, Object>? context,
+    Object? body,
+  }) {
     throw UnimplementedError();
   }
 }
 
-Message _createMessage(
-    {Map<String, /* String | List<String> */ Object>? headers,
-    Map<String, Object>? context,
-    Object? body,
-    Encoding? encoding}) {
+Message _createMessage({
+  Map<String, /* String | List<String> */ Object>? headers,
+  Map<String, Object>? context,
+  Object? body,
+  Encoding? encoding,
+}) {
   return _TestMessage(headers, context, body, encoding);
 }
 
@@ -52,7 +57,9 @@ void main() {
       expect(message.headers, same(_createMessage().headers));
       expect(() => message.headers['h1'] = 'value1', throwsUnsupportedError);
       expect(
-          () => message.headersAll['h1'] = ['value1'], throwsUnsupportedError);
+        () => message.headersAll['h1'] = ['value1'],
+        throwsUnsupportedError,
+      );
     });
 
     test('headers are immutable', () {
@@ -61,23 +68,27 @@ void main() {
       expect(() => message.headers['h1'] = 'value2', throwsUnsupportedError);
       expect(() => message.headers['h2'] = 'value2', throwsUnsupportedError);
       expect(
-          () => message.headersAll['h1'] = ['value1'], throwsUnsupportedError);
+        () => message.headersAll['h1'] = ['value1'],
+        throwsUnsupportedError,
+      );
       expect(
-          () => message.headersAll['h1'] = ['value2'], throwsUnsupportedError);
+        () => message.headersAll['h1'] = ['value2'],
+        throwsUnsupportedError,
+      );
       expect(
-          () => message.headersAll['h2'] = ['value2'], throwsUnsupportedError);
+        () => message.headersAll['h2'] = ['value2'],
+        throwsUnsupportedError,
+      );
     });
 
     test('headers with multiple values', () {
-      final message = _createMessage(headers: {
-        'a': 'A',
-        'b': ['B1', 'B2'],
-      });
-      expect(message.headers, {
-        'a': 'A',
-        'b': 'B1,B2',
-        'content-length': '0',
-      });
+      final message = _createMessage(
+        headers: {
+          'a': 'A',
+          'b': ['B1', 'B2'],
+        },
+      );
+      expect(message.headers, {'a': 'A', 'b': 'B1,B2', 'content-length': '0'});
       expect(message.headersAll, {
         'a': ['A'],
         'b': ['B1', 'B2'],
@@ -126,27 +137,30 @@ void main() {
 
     test('defaults to UTF-8', () {
       var request = _createMessage(
-          body: Stream.fromIterable([
-        [195, 168]
-      ]));
+        body: Stream.fromIterable([
+          [195, 168],
+        ]),
+      );
       expect(request.readAsString(), completion(equals('è')));
     });
 
     test('the content-type header overrides the default', () {
       var request = _createMessage(
-          headers: {'content-type': 'text/plain; charset=iso-8859-1'},
-          body: Stream.fromIterable([
-            [195, 168]
-          ]));
+        headers: {'content-type': 'text/plain; charset=iso-8859-1'},
+        body: Stream.fromIterable([
+          [195, 168],
+        ]),
+      );
       expect(request.readAsString(), completion(equals('Ã¨')));
     });
 
     test('an explicit encoding overrides the content-type header', () {
       var request = _createMessage(
-          headers: {'content-type': 'text/plain; charset=iso-8859-1'},
-          body: Stream.fromIterable([
-            [195, 168]
-          ]));
+        headers: {'content-type': 'text/plain; charset=iso-8859-1'},
+        body: Stream.fromIterable([
+          [195, 168],
+        ]),
+      );
       expect(request.readAsString(latin1), completion(equals('Ã¨')));
     });
   });
@@ -160,8 +174,10 @@ void main() {
     test('supports a Stream<List<int>> body', () {
       var controller = StreamController<Object>();
       var request = _createMessage(body: controller.stream);
-      expect(request.read().toList(),
-          completion(equals([helloBytes, worldBytes])));
+      expect(
+        request.read().toList(),
+        completion(equals([helloBytes, worldBytes])),
+      );
 
       controller.add(helloBytes);
       return Future(() {
@@ -228,44 +244,57 @@ void main() {
 
     test('uses the content-length header for a stream body', () {
       var request = _createMessage(
-          body: const Stream<List<int>>.empty(),
-          headers: {'content-length': '42'});
+        body: const Stream<List<int>>.empty(),
+        headers: {'content-length': '42'},
+      );
       expect(request.contentLength, 42);
     });
 
     test('real body length takes precedence over content-length header', () {
-      var request =
-          _createMessage(body: [1, 2, 3], headers: {'content-length': '42'});
+      var request = _createMessage(
+        body: [1, 2, 3],
+        headers: {'content-length': '42'},
+      );
       expect(request.contentLength, 3);
     });
 
     test('is null for a chunked transfer encoding', () {
       var request = _createMessage(
-          body: '1\r\na0\r\n\r\n', headers: {'transfer-encoding': 'chunked'});
+        body: '1\r\na0\r\n\r\n',
+        headers: {'transfer-encoding': 'chunked'},
+      );
       expect(request.contentLength, isNull);
     });
 
     test('is null for a chunked transfer encoding with a different case', () {
       var request = _createMessage(
-          body: '1\r\na0\r\n\r\n', headers: {'Transfer-Encoding': 'chunked'});
+        body: '1\r\na0\r\n\r\n',
+        headers: {'Transfer-Encoding': 'chunked'},
+      );
       expect(request.contentLength, isNull);
     });
 
     test('is null for a non-identity transfer encoding', () {
       var request = _createMessage(
-          body: '1\r\na0\r\n\r\n', headers: {'transfer-encoding': 'custom'});
+        body: '1\r\na0\r\n\r\n',
+        headers: {'transfer-encoding': 'custom'},
+      );
       expect(request.contentLength, isNull);
     });
 
     test('is set for identity transfer encoding', () {
       var request = _createMessage(
-          body: '1\r\na0\r\n\r\n', headers: {'transfer-encoding': 'identity'});
+        body: '1\r\na0\r\n\r\n',
+        headers: {'transfer-encoding': 'identity'},
+      );
       expect(request.contentLength, equals(9));
     });
 
     test('is set for identity transfer encoding with a different case', () {
       var request = _createMessage(
-          body: '1\r\na0\r\n\r\n', headers: {'Transfer-Encoding': 'identity'});
+        body: '1\r\na0\r\n\r\n',
+        headers: {'Transfer-Encoding': 'identity'},
+      );
       expect(request.contentLength, equals(9));
     });
   });
@@ -276,16 +305,19 @@ void main() {
     });
 
     test('comes from the content-type header', () {
-      expect(_createMessage(headers: {'content-type': 'text/plain'}).mimeType,
-          equals('text/plain'));
+      expect(
+        _createMessage(headers: {'content-type': 'text/plain'}).mimeType,
+        equals('text/plain'),
+      );
     });
 
     test("doesn't include parameters", () {
       expect(
-          _createMessage(
-                  headers: {'content-type': 'text/plain; foo=bar; bar=baz'})
-              .mimeType,
-          equals('text/plain'));
+        _createMessage(
+          headers: {'content-type': 'text/plain; foo=bar; bar=baz'},
+        ).mimeType,
+        equals('text/plain'),
+      );
     });
   });
 
@@ -295,82 +327,113 @@ void main() {
     });
 
     test('is null without a charset parameter', () {
-      expect(_createMessage(headers: {'content-type': 'text/plain'}).encoding,
-          isNull);
+      expect(
+        _createMessage(headers: {'content-type': 'text/plain'}).encoding,
+        isNull,
+      );
     });
 
     test('is null with an unrecognized charset parameter', () {
       expect(
-          _createMessage(
-              headers: {'content-type': 'text/plain; charset=fblthp'}).encoding,
-          isNull);
+        _createMessage(
+          headers: {'content-type': 'text/plain; charset=fblthp'},
+        ).encoding,
+        isNull,
+      );
     });
 
     test('comes from the content-type charset parameter', () {
       expect(
-          _createMessage(
-                  headers: {'content-type': 'text/plain; charset=iso-8859-1'})
-              .encoding,
-          equals(latin1));
+        _createMessage(
+          headers: {'content-type': 'text/plain; charset=iso-8859-1'},
+        ).encoding,
+        equals(latin1),
+      );
     });
 
-    test('comes from the content-type charset parameter with a different case',
-        () {
-      expect(
+    test(
+      'comes from the content-type charset parameter with a different case',
+      () {
+        expect(
           _createMessage(
-                  headers: {'Content-Type': 'text/plain; charset=iso-8859-1'})
-              .encoding,
-          equals(latin1));
-    });
+            headers: {'Content-Type': 'text/plain; charset=iso-8859-1'},
+          ).encoding,
+          equals(latin1),
+        );
+      },
+    );
 
     test('defaults to encoding a String as UTF-8', () {
       expect(
-          _createMessage(body: 'è').read().toList(),
-          completion(equals([
-            [195, 168]
-          ])));
+        _createMessage(body: 'è').read().toList(),
+        completion(
+          equals([
+            [195, 168],
+          ]),
+        ),
+      );
     });
 
     test('uses the explicit encoding if available', () {
       expect(
-          _createMessage(body: 'è', encoding: latin1).read().toList(),
-          completion(equals([
-            [232]
-          ])));
+        _createMessage(body: 'è', encoding: latin1).read().toList(),
+        completion(
+          equals([
+            [232],
+          ]),
+        ),
+      );
     });
 
     test('adds an explicit encoding to the content-type', () {
       var request = _createMessage(
-          body: 'è', encoding: latin1, headers: {'content-type': 'text/plain'});
-      expect(request.headers,
-          containsPair('content-type', 'text/plain; charset=iso-8859-1'));
-    });
-
-    test('adds an explicit encoding to the content-type with a different case',
-        () {
-      var request = _createMessage(
-          body: 'è', encoding: latin1, headers: {'Content-Type': 'text/plain'});
-      expect(request.headers,
-          containsPair('Content-Type', 'text/plain; charset=iso-8859-1'));
+        body: 'è',
+        encoding: latin1,
+        headers: {'content-type': 'text/plain'},
+      );
+      expect(
+        request.headers,
+        containsPair('content-type', 'text/plain; charset=iso-8859-1'),
+      );
     });
 
     test(
-        'sets an absent content-type to application/octet-stream in order to '
+      'adds an explicit encoding to the content-type with a different case',
+      () {
+        var request = _createMessage(
+          body: 'è',
+          encoding: latin1,
+          headers: {'Content-Type': 'text/plain'},
+        );
+        expect(
+          request.headers,
+          containsPair('Content-Type', 'text/plain; charset=iso-8859-1'),
+        );
+      },
+    );
+
+    test('sets an absent content-type to application/octet-stream in order to '
         'set the charset', () {
       var request = _createMessage(body: 'è', encoding: latin1);
       expect(
-          request.headers,
-          containsPair(
-              'content-type', 'application/octet-stream; charset=iso-8859-1'));
+        request.headers,
+        containsPair(
+          'content-type',
+          'application/octet-stream; charset=iso-8859-1',
+        ),
+      );
     });
 
     test('overwrites an existing charset if given an explicit encoding', () {
       var request = _createMessage(
-          body: 'è',
-          encoding: latin1,
-          headers: {'content-type': 'text/plain; charset=whatever'});
-      expect(request.headers,
-          containsPair('content-type', 'text/plain; charset=iso-8859-1'));
+        body: 'è',
+        encoding: latin1,
+        headers: {'content-type': 'text/plain; charset=whatever'},
+      );
+      expect(
+        request.headers,
+        containsPair('content-type', 'text/plain; charset=iso-8859-1'),
+      );
     });
   });
 }

--- a/pkgs/shelf/test/pipeline_test.dart
+++ b/pkgs/shelf/test/pipeline_test.dart
@@ -15,22 +15,22 @@ void main() {
   });
 
   Handler middlewareA(Handler innerHandler) => (request) {
-        expect(accessLocation, 0);
-        accessLocation = 1;
-        final response = innerHandler(request);
-        expect(accessLocation, 4);
-        accessLocation = 5;
-        return response;
-      };
+    expect(accessLocation, 0);
+    accessLocation = 1;
+    final response = innerHandler(request);
+    expect(accessLocation, 4);
+    accessLocation = 5;
+    return response;
+  };
 
   Handler middlewareB(Handler innerHandler) => (request) {
-        expect(accessLocation, 1);
-        accessLocation = 2;
-        final response = innerHandler(request);
-        expect(accessLocation, 3);
-        accessLocation = 4;
-        return response;
-      };
+    expect(accessLocation, 1);
+    accessLocation = 2;
+    final response = innerHandler(request);
+    expect(accessLocation, 3);
+    accessLocation = 4;
+    return response;
+  };
 
   Response innerHandler(Request request) {
     expect(accessLocation, 2);
@@ -50,8 +50,9 @@ void main() {
   });
 
   test('extensions for composition', () async {
-    var handler =
-        middlewareA.addMiddleware(middlewareB).addHandler(innerHandler);
+    var handler = middlewareA
+        .addMiddleware(middlewareB)
+        .addHandler(innerHandler);
 
     final response = await makeSimpleRequest(handler);
     expect(response, isNotNull);
@@ -59,8 +60,9 @@ void main() {
   });
 
   test('Pipeline can be used as middleware', () async {
-    var innerPipeline =
-        const Pipeline().addMiddleware(middlewareA).addMiddleware(middlewareB);
+    var innerPipeline = const Pipeline()
+        .addMiddleware(middlewareA)
+        .addMiddleware(middlewareB);
 
     var handler = const Pipeline()
         .addMiddleware(innerPipeline.middleware)

--- a/pkgs/shelf/test/request_test.dart
+++ b/pkgs/shelf/test/request_test.dart
@@ -10,10 +10,18 @@ import 'package:test/test.dart';
 
 import 'test_util.dart';
 
-Request _request(
-    {Map<String, String>? headers, Object? body, Encoding? encoding}) {
-  return Request('GET', localhostUri,
-      headers: headers, body: body, encoding: encoding);
+Request _request({
+  Map<String, String>? headers,
+  Object? body,
+  Encoding? encoding,
+}) {
+  return Request(
+    'GET',
+    localhostUri,
+    headers: headers,
+    body: body,
+    encoding: encoding,
+  );
 }
 
 void main() {
@@ -45,26 +53,37 @@ void main() {
       });
 
       test('may contain slash', () {
-        var request =
-            Request('GET', Uri.parse('http://localhost/foo/bar%2f42'));
+        var request = Request(
+          'GET',
+          Uri.parse('http://localhost/foo/bar%2f42'),
+        );
         expect(request.url, equals(Uri.parse('foo/bar%2f42')));
       });
 
       test('is inferred from handlerPath if possible', () {
-        var request = Request('GET', Uri.parse('http://localhost/foo/bar?q=1'),
-            handlerPath: '/foo/');
+        var request = Request(
+          'GET',
+          Uri.parse('http://localhost/foo/bar?q=1'),
+          handlerPath: '/foo/',
+        );
         expect(request.url, equals(Uri.parse('bar?q=1')));
       });
 
       test('uses the given value if passed', () {
-        var request = Request('GET', Uri.parse('http://localhost/foo/bar?q=1'),
-            url: Uri.parse('bar?q=1'));
+        var request = Request(
+          'GET',
+          Uri.parse('http://localhost/foo/bar?q=1'),
+          url: Uri.parse('bar?q=1'),
+        );
         expect(request.url, equals(Uri.parse('bar?q=1')));
       });
 
       test('may be empty', () {
-        var request = Request('GET', Uri.parse('http://localhost/foo/bar'),
-            url: Uri.parse(''));
+        var request = Request(
+          'GET',
+          Uri.parse('http://localhost/foo/bar'),
+          url: Uri.parse(''),
+        );
         expect(request.url, equals(Uri.parse('')));
       });
     });
@@ -76,27 +95,39 @@ void main() {
       });
 
       test('is inferred from url if possible', () {
-        var request = Request('GET', Uri.parse('http://localhost/foo/bar?q=1'),
-            url: Uri.parse('bar?q=1'));
+        var request = Request(
+          'GET',
+          Uri.parse('http://localhost/foo/bar?q=1'),
+          url: Uri.parse('bar?q=1'),
+        );
         expect(request.handlerPath, equals('/foo/'));
       });
 
       test('uses the given value if passed', () {
-        var request = Request('GET', Uri.parse('http://localhost/foo/bar?q=1'),
-            handlerPath: '/foo/');
+        var request = Request(
+          'GET',
+          Uri.parse('http://localhost/foo/bar?q=1'),
+          handlerPath: '/foo/',
+        );
         expect(request.handlerPath, equals('/foo/'));
       });
 
       test('adds a trailing slash to the given value if necessary', () {
-        var request = Request('GET', Uri.parse('http://localhost/foo/bar?q=1'),
-            handlerPath: '/foo');
+        var request = Request(
+          'GET',
+          Uri.parse('http://localhost/foo/bar?q=1'),
+          handlerPath: '/foo',
+        );
         expect(request.handlerPath, equals('/foo/'));
         expect(request.url, equals(Uri.parse('bar?q=1')));
       });
 
       test('may be a single slash', () {
-        var request = Request('GET', Uri.parse('http://localhost/foo/bar?q=1'),
-            handlerPath: '/');
+        var request = Request(
+          'GET',
+          Uri.parse('http://localhost/foo/bar?q=1'),
+          handlerPath: '/',
+        );
         expect(request.handlerPath, equals('/'));
         expect(request.url, equals(Uri.parse('foo/bar?q=1')));
       });
@@ -118,42 +149,60 @@ void main() {
       group('url', () {
         test('must be relative', () {
           expect(() {
-            Request('GET', Uri.parse('http://localhost/test'),
-                url: Uri.parse('http://localhost/test'));
+            Request(
+              'GET',
+              Uri.parse('http://localhost/test'),
+              url: Uri.parse('http://localhost/test'),
+            );
           }, throwsArgumentError);
         });
 
         test('may not be root-relative', () {
           expect(() {
-            Request('GET', Uri.parse('http://localhost/test'),
-                url: Uri.parse('/test'));
+            Request(
+              'GET',
+              Uri.parse('http://localhost/test'),
+              url: Uri.parse('/test'),
+            );
           }, throwsArgumentError);
         });
 
         test('may not have a fragment', () {
           expect(() {
-            Request('GET', Uri.parse('http://localhost/test'),
-                url: Uri.parse('test#fragment'));
+            Request(
+              'GET',
+              Uri.parse('http://localhost/test'),
+              url: Uri.parse('test#fragment'),
+            );
           }, throwsArgumentError);
         });
 
         test('must be a suffix of requestedUri', () {
           expect(() {
-            Request('GET', Uri.parse('http://localhost/dir/test'),
-                url: Uri.parse('dir'));
+            Request(
+              'GET',
+              Uri.parse('http://localhost/dir/test'),
+              url: Uri.parse('dir'),
+            );
           }, throwsArgumentError);
         });
 
         test('must have the same query parameters as requestedUri', () {
           expect(() {
-            Request('GET', Uri.parse('http://localhost/test?q=1&r=2'),
-                url: Uri.parse('test?q=2&r=1'));
+            Request(
+              'GET',
+              Uri.parse('http://localhost/test?q=1&r=2'),
+              url: Uri.parse('test?q=2&r=1'),
+            );
           }, throwsArgumentError);
 
           // Order matters for query parameters.
           expect(() {
-            Request('GET', Uri.parse('http://localhost/test?q=1&r=2'),
-                url: Uri.parse('test?r=2&q=1'));
+            Request(
+              'GET',
+              Uri.parse('http://localhost/test?q=1&r=2'),
+              url: Uri.parse('test?r=2&q=1'),
+            );
           }, throwsArgumentError);
         });
       });
@@ -161,22 +210,32 @@ void main() {
       group('handlerPath', () {
         test('must be a prefix of requestedUri', () {
           expect(() {
-            Request('GET', Uri.parse('http://localhost/dir/test'),
-                handlerPath: '/test');
+            Request(
+              'GET',
+              Uri.parse('http://localhost/dir/test'),
+              handlerPath: '/test',
+            );
           }, throwsArgumentError);
         });
 
         test('must start with "/"', () {
           expect(() {
-            Request('GET', Uri.parse('http://localhost/test'),
-                handlerPath: 'test');
+            Request(
+              'GET',
+              Uri.parse('http://localhost/test'),
+              handlerPath: 'test',
+            );
           }, throwsArgumentError);
         });
 
         test('must be the requestedUri path if url is empty', () {
           expect(() {
-            Request('GET', Uri.parse('http://localhost/test'),
-                handlerPath: '/', url: Uri.parse(''));
+            Request(
+              'GET',
+              Uri.parse('http://localhost/test'),
+              handlerPath: '/',
+              url: Uri.parse(''),
+            );
           }, throwsArgumentError);
         });
       });
@@ -184,15 +243,23 @@ void main() {
       group('handlerPath + url must', () {
         test('be requestedUrl path', () {
           expect(() {
-            Request('GET', Uri.parse('http://localhost/foo/bar/baz'),
-                handlerPath: '/foo/', url: Uri.parse('baz'));
+            Request(
+              'GET',
+              Uri.parse('http://localhost/foo/bar/baz'),
+              handlerPath: '/foo/',
+              url: Uri.parse('baz'),
+            );
           }, throwsArgumentError);
         });
 
         test('be on a path boundary', () {
           expect(() {
-            Request('GET', Uri.parse('http://localhost/foo/bar/baz'),
-                handlerPath: '/foo/ba', url: Uri.parse('r/baz'));
+            Request(
+              'GET',
+              Uri.parse('http://localhost/foo/bar/baz'),
+              handlerPath: '/foo/ba',
+              url: Uri.parse('r/baz'),
+            );
           }, throwsArgumentError);
         });
       });
@@ -207,9 +274,12 @@ void main() {
 
     test('comes from the Last-Modified header', () {
       var request = _request(
-          headers: {'if-modified-since': 'Sun, 06 Nov 1994 08:49:37 GMT'});
-      expect(request.ifModifiedSince,
-          equals(DateTime.parse('1994-11-06 08:49:37z')));
+        headers: {'if-modified-since': 'Sun, 06 Nov 1994 08:49:37 GMT'},
+      );
+      expect(
+        request.ifModifiedSince,
+        equals(DateTime.parse('1994-11-06 08:49:37z')),
+      );
     });
   });
 
@@ -219,13 +289,16 @@ void main() {
 
       var uri = Uri.parse('https://test.example.com/static/file.html');
 
-      var request = Request('GET', uri,
-          protocolVersion: '2.0',
-          headers: {'header1': 'header value 1'},
-          url: Uri.parse('file.html'),
-          handlerPath: '/static/',
-          body: controller.stream,
-          context: {'context1': 'context value 1'});
+      var request = Request(
+        'GET',
+        uri,
+        protocolVersion: '2.0',
+        headers: {'header1': 'header value 1'},
+        url: Uri.parse('file.html'),
+        handlerPath: '/static/',
+        body: controller.stream,
+        context: {'context1': 'context value 1'},
+      );
 
       var copy = request.change();
 
@@ -249,13 +322,15 @@ void main() {
 
     group('change headers', () {
       final request = Request(
-          'GET', Uri.parse('http://localhost:8080/static/file.html'),
-          protocolVersion: '2.0',
-          headers: {'header1': 'header value 1'},
-          url: Uri.parse('file.html'),
-          handlerPath: '/static/',
-          body: '',
-          context: {'context1': 'context value 1'});
+        'GET',
+        Uri.parse('http://localhost:8080/static/file.html'),
+        protocolVersion: '2.0',
+        headers: {'header1': 'header value 1'},
+        url: Uri.parse('file.html'),
+        handlerPath: '/static/',
+        body: '',
+        context: {'context1': 'context value 1'},
+      );
 
       test('delete value with null', () {
         final r = request.change(
@@ -290,9 +365,11 @@ void main() {
       });
 
       test('override value with new single-item List', () {
-        final r = request.change(headers: {
-          'header1': ['new header value']
-        });
+        final r = request.change(
+          headers: {
+            'header1': ['new header value'],
+          },
+        );
         expect(r.headers, {
           'header1': 'new header value',
           'content-length': '0',
@@ -304,9 +381,11 @@ void main() {
       });
 
       test('override value with new multi-item List', () {
-        final r = request.change(headers: {
-          'header1': ['new header value', 'other value']
-        });
+        final r = request.change(
+          headers: {
+            'header1': ['new header value', 'other value'],
+          },
+        );
         expect(r.headers, {
           'header1': 'new header value,other value',
           'content-length': '0',
@@ -318,16 +397,20 @@ void main() {
       });
 
       test('adding a new values', () {
-        final r = request.change(headers: {
-          'a': 'A',
-          'b': ['B1', 'B2'],
-        }).change(headers: {'c': 'C'});
+        final r = request
+            .change(
+              headers: {
+                'a': 'A',
+                'b': ['B1', 'B2'],
+              },
+            )
+            .change(headers: {'c': 'C'});
         expect(r.headers, {
           'header1': 'header value 1',
           'content-length': '0',
           'a': 'A',
           'b': 'B1,B2',
-          'c': 'C'
+          'c': 'C',
         });
         expect(r.headersAll, {
           'header1': ['header value 1'],
@@ -342,8 +425,12 @@ void main() {
     group('with path', () {
       test('updates handlerPath and url', () {
         var uri = Uri.parse('https://test.example.com/static/dir/file.html');
-        var request = Request('GET', uri,
-            handlerPath: '/static/', url: Uri.parse('dir/file.html'));
+        var request = Request(
+          'GET',
+          uri,
+          handlerPath: '/static/',
+          url: Uri.parse('dir/file.html'),
+        );
         var copy = request.change(path: 'dir');
 
         expect(copy.handlerPath, '/static/dir/');
@@ -352,8 +439,12 @@ void main() {
 
       test('allows a trailing slash', () {
         var uri = Uri.parse('https://test.example.com/static/dir/file.html');
-        var request = Request('GET', uri,
-            handlerPath: '/static/', url: Uri.parse('dir/file.html'));
+        var request = Request(
+          'GET',
+          uri,
+          handlerPath: '/static/',
+          url: Uri.parse('dir/file.html'),
+        );
         var copy = request.change(path: 'dir/');
 
         expect(copy.handlerPath, '/static/dir/');
@@ -362,8 +453,12 @@ void main() {
 
       test('regression test for Issue #142', () {
         var uri = Uri.parse('https://test.example.com/static/dir/');
-        var request = Request('GET', uri,
-            handlerPath: '/static/', url: Uri.parse('dir/'));
+        var request = Request(
+          'GET',
+          uri,
+          handlerPath: '/static/',
+          url: Uri.parse('dir/'),
+        );
 
         var copy = request.change(path: 'dir');
         expect(copy.handlerPath, '/static/dir/');
@@ -372,8 +467,12 @@ void main() {
 
       test('allows changing path leading to double //', () {
         var uri = Uri.parse('https://test.example.com/some_base//more');
-        var request = Request('GET', uri,
-            handlerPath: '', url: Uri.parse('some_base//more'));
+        var request = Request(
+          'GET',
+          uri,
+          handlerPath: '',
+          url: Uri.parse('some_base//more'),
+        );
 
         var copy = request.change(path: 'some_base');
         expect(copy.handlerPath, '/some_base/');
@@ -382,16 +481,24 @@ void main() {
 
       test('throws if path does not match existing uri', () {
         var uri = Uri.parse('https://test.example.com/static/dir/file.html');
-        var request = Request('GET', uri,
-            handlerPath: '/static/', url: Uri.parse('dir/file.html'));
+        var request = Request(
+          'GET',
+          uri,
+          handlerPath: '/static/',
+          url: Uri.parse('dir/file.html'),
+        );
 
         expect(() => request.change(path: 'wrong'), throwsArgumentError);
       });
 
       test("throws if path isn't a path boundary", () {
         var uri = Uri.parse('https://test.example.com/static/dir/file.html');
-        var request = Request('GET', uri,
-            handlerPath: '/static/', url: Uri.parse('dir/file.html'));
+        var request = Request(
+          'GET',
+          uri,
+          handlerPath: '/static/',
+          url: Uri.parse('dir/file.html'),
+        );
 
         expect(() => request.change(path: 'di'), throwsArgumentError);
       });

--- a/pkgs/shelf/test/response_test.dart
+++ b/pkgs/shelf/test/response_test.dart
@@ -54,8 +54,10 @@ void main() {
     var response = Response.ok(bytes);
 
     expect(response.contentLength, 4);
-    expect(await response.read().single,
-        isA<List<int>>().having((values) => values, 'values', [1, 2, 3, 4]));
+    expect(
+      await response.read().single,
+      isA<List<int>>().having((values) => values, 'values', [1, 2, 3, 4]),
+    );
   });
 
   test('allows content-length header even if body is null', () async {
@@ -77,7 +79,9 @@ void main() {
     test('sets the body to "Internal Server Error"', () {
       var response = Response.internalServerError();
       expect(
-          response.readAsString(), completion(equals('Internal Server Error')));
+        response.readAsString(),
+        completion(equals('Internal Server Error')),
+      );
     });
 
     test('sets the content-type header to text/plain', () {
@@ -86,11 +90,13 @@ void main() {
     });
 
     test('preserves content-type parameters', () {
-      var response = Response.internalServerError(headers: {
-        'content-type': 'application/octet-stream; param=whatever'
-      });
-      expect(response.headers,
-          containsPair('content-type', 'text/plain; param=whatever'));
+      var response = Response.internalServerError(
+        headers: {'content-type': 'application/octet-stream; param=whatever'},
+      );
+      expect(
+        response.headers,
+        containsPair('content-type', 'text/plain; param=whatever'),
+      );
     });
   });
 
@@ -110,7 +116,9 @@ void main() {
     test('sets body', () {
       var response = Response.unauthorized('request unauthorized');
       expect(
-          response.readAsString(), completion(equals('request unauthorized')));
+        response.readAsString(),
+        completion(equals('request unauthorized')),
+      );
       expect(response.statusCode, 401);
     });
   });
@@ -134,9 +142,12 @@ void main() {
 
     test('comes from the Expires header', () {
       expect(
-          Response.ok('okay!',
-              headers: {'expires': 'Sun, 06 Nov 1994 08:49:37 GMT'}).expires,
-          equals(DateTime.parse('1994-11-06 08:49:37z')));
+        Response.ok(
+          'okay!',
+          headers: {'expires': 'Sun, 06 Nov 1994 08:49:37 GMT'},
+        ).expires,
+        equals(DateTime.parse('1994-11-06 08:49:37z')),
+      );
     });
   });
 
@@ -147,10 +158,12 @@ void main() {
 
     test('comes from the Last-Modified header', () {
       expect(
-          Response.ok('okay!',
-                  headers: {'last-modified': 'Sun, 06 Nov 1994 08:49:37 GMT'})
-              .lastModified,
-          equals(DateTime.parse('1994-11-06 08:49:37z')));
+        Response.ok(
+          'okay!',
+          headers: {'last-modified': 'Sun, 06 Nov 1994 08:49:37 GMT'},
+        ).lastModified,
+        equals(DateTime.parse('1994-11-06 08:49:37z')),
+      );
     });
   });
 
@@ -158,11 +171,13 @@ void main() {
     test('with no arguments returns instance with equal values', () {
       var controller = StreamController<Object>();
 
-      var request = Response(345,
-          body: 'hèllo, world',
-          encoding: latin1,
-          headers: {'header1': 'header value 1'},
-          context: {'context1': 'context value 1'});
+      var request = Response(
+        345,
+        body: 'hèllo, world',
+        encoding: latin1,
+        headers: {'header1': 'header value 1'},
+        context: {'context1': 'context value 1'},
+      );
 
       var copy = request.change();
 
@@ -246,9 +261,11 @@ void main() {
       });
 
       test('override value with new single-item List', () {
-        final r = response.change(headers: {
-          'header1': ['new header value']
-        });
+        final r = response.change(
+          headers: {
+            'header1': ['new header value'],
+          },
+        );
         expect(r.headers, {
           'header1': 'new header value',
           'content-length': '0',
@@ -260,9 +277,11 @@ void main() {
       });
 
       test('override value with new multi-item List', () {
-        final r = response.change(headers: {
-          'header1': ['new header value', 'other value']
-        });
+        final r = response.change(
+          headers: {
+            'header1': ['new header value', 'other value'],
+          },
+        );
         expect(r.headers, {
           'header1': 'new header value,other value',
           'content-length': '0',
@@ -274,16 +293,20 @@ void main() {
       });
 
       test('adding a new values', () {
-        final r = response.change(headers: {
-          'a': 'A',
-          'b': ['B1', 'B2'],
-        }).change(headers: {'c': 'C'});
+        final r = response
+            .change(
+              headers: {
+                'a': 'A',
+                'b': ['B1', 'B2'],
+              },
+            )
+            .change(headers: {'c': 'C'});
         expect(r.headers, {
           'header1': 'header value 1',
           'content-length': '0',
           'a': 'A',
           'b': 'B1,B2',
-          'c': 'C'
+          'c': 'C',
         });
         expect(r.headersAll, {
           'header1': ['header value 1'],

--- a/pkgs/shelf/test/server_handler_test.dart
+++ b/pkgs/shelf/test/server_handler_test.dart
@@ -17,27 +17,31 @@ void main() {
     expect(serverHandler.server.url, equals(localhostUri));
   });
 
-  test('pipes a request from ServerHandler.handler to a mounted handler',
-      () async {
-    var serverHandler = ServerHandler(localhostUri);
-    serverHandler.server.mount(asyncHandler);
+  test(
+    'pipes a request from ServerHandler.handler to a mounted handler',
+    () async {
+      var serverHandler = ServerHandler(localhostUri);
+      serverHandler.server.mount(asyncHandler);
 
-    var response = await makeSimpleRequest(serverHandler.handler);
-    expect(response.statusCode, equals(200));
-    expect(response.readAsString(), completion(equals('Hello from /')));
-  });
+      var response = await makeSimpleRequest(serverHandler.handler);
+      expect(response.statusCode, equals(200));
+      expect(response.readAsString(), completion(equals('Hello from /')));
+    },
+  );
 
-  test("waits until the server's handler is mounted to service a request",
-      () async {
-    var serverHandler = ServerHandler(localhostUri);
-    var future = makeSimpleRequest(serverHandler.handler);
-    await Future<void>.delayed(Duration.zero);
+  test(
+    "waits until the server's handler is mounted to service a request",
+    () async {
+      var serverHandler = ServerHandler(localhostUri);
+      var future = makeSimpleRequest(serverHandler.handler);
+      await Future<void>.delayed(Duration.zero);
 
-    serverHandler.server.mount(syncHandler);
-    var response = await future;
-    expect(response.statusCode, equals(200));
-    expect(response.readAsString(), completion(equals('Hello from /')));
-  });
+      serverHandler.server.mount(syncHandler);
+      var response = await future;
+      expect(response.statusCode, equals(200));
+      expect(response.readAsString(), completion(equals('Hello from /')));
+    },
+  );
 
   test('stops servicing requests after Server.close is called', () {
     var serverHandler = ServerHandler(localhostUri);
@@ -52,15 +56,20 @@ void main() {
   test('calls onClose when Server.close is called', () async {
     var onCloseCalled = false;
     var completer = Completer<void>();
-    var serverHandler = ServerHandler(localhostUri, onClose: () {
-      onCloseCalled = true;
-      return completer.future;
-    });
+    var serverHandler = ServerHandler(
+      localhostUri,
+      onClose: () {
+        onCloseCalled = true;
+        return completer.future;
+      },
+    );
 
     var closeDone = false;
-    unawaited(serverHandler.server.close().then((_) {
-      closeDone = true;
-    }));
+    unawaited(
+      serverHandler.server.close().then((_) {
+        closeDone = true;
+      }),
+    );
     expect(onCloseCalled, isTrue);
     await Future<void>.delayed(Duration.zero);
 

--- a/pkgs/shelf/test/shelf_io_test.dart
+++ b/pkgs/shelf/test/shelf_io_test.dart
@@ -105,21 +105,30 @@ void main() {
   });
 
   test('chunked requests are un-chunked', () async {
-    await _scheduleServer(expectAsync1((request) {
-      expect(request.contentLength, isNull);
-      expect(request.method, 'POST');
-      expect(
-          request.headers, isNot(contains(HttpHeaders.transferEncodingHeader)));
-      expect(
+    await _scheduleServer(
+      expectAsync1((request) {
+        expect(request.contentLength, isNull);
+        expect(request.method, 'POST');
+        expect(
+          request.headers,
+          isNot(contains(HttpHeaders.transferEncodingHeader)),
+        );
+        expect(
           request.read().toList(),
-          completion(equals([
-            [1, 2, 3, 4]
-          ])));
-      return Response.ok(null);
-    }));
+          completion(
+            equals([
+              [1, 2, 3, 4],
+            ]),
+          ),
+        );
+        return Response.ok(null);
+      }),
+    );
 
-    var request =
-        http.StreamedRequest('POST', Uri.http('localhost:$_serverPort', ''));
+    var request = http.StreamedRequest(
+      'POST',
+      Uri.http('localhost:$_serverPort', ''),
+    );
     request.sink.add([1, 2, 3, 4]);
     // ignore: unawaited_futures
     request.sink.close();
@@ -130,8 +139,10 @@ void main() {
 
   test('custom response headers are received by the client', () async {
     await _scheduleServer((request) {
-      return Response.ok('Hello from /',
-          headers: {'test-header': 'test-value', 'test-list': 'a, b, c'});
+      return Response.ok(
+        'Hello from /',
+        headers: {'test-header': 'test-value', 'test-list': 'a, b, c'},
+      );
     });
 
     var response = await _get();
@@ -142,20 +153,27 @@ void main() {
 
   test('multiple headers are received from the client', () async {
     await _scheduleServer((request) {
-      return Response.ok('Hello from /', headers: {
-        'requested-values': request.headersAll['request-values']!,
-        'requested-values-length':
-            request.headersAll['request-values']!.length.toString(),
-        'set-cookie-values': request.headersAll['set-cookie']!,
-        'set-cookie-values-length':
-            request.headersAll['set-cookie']!.length.toString(),
-      });
+      return Response.ok(
+        'Hello from /',
+        headers: {
+          'requested-values': request.headersAll['request-values']!,
+          'requested-values-length': request
+              .headersAll['request-values']!
+              .length
+              .toString(),
+          'set-cookie-values': request.headersAll['set-cookie']!,
+          'set-cookie-values-length': request.headersAll['set-cookie']!.length
+              .toString(),
+        },
+      );
     });
 
-    final response = await _get(headers: {
-      'request-values': ['a', 'b'],
-      'set-cookie': ['c', 'd'],
-    });
+    final response = await _get(
+      headers: {
+        'request-values': ['a', 'b'],
+        'set-cookie': ['c', 'd'],
+      },
+    );
     expect(response.statusCode, HttpStatus.ok);
     expect(response.headers['requested-values'], 'a, b');
     expect(response.headers['requested-values-length'], '1');
@@ -185,7 +203,7 @@ void main() {
 
     var headers = {
       'custom-header': 'client value',
-      'multi-header': 'foo,bar,baz'
+      'multi-header': 'foo,bar,baz',
     };
 
     var response = await _get(headers: headers);
@@ -231,56 +249,77 @@ void main() {
     await _scheduleServer((request) {
       expect(request.method, 'POST');
 
-      request.hijack(expectAsync1((channel) {
-        expect(channel.stream.first, completion(equals('Hello'.codeUnits)));
+      request.hijack(
+        expectAsync1((channel) {
+          expect(channel.stream.first, completion(equals('Hello'.codeUnits)));
 
-        channel.sink.add('HTTP/1.1 404 Not Found\r\n'
-                'date: Mon, 23 May 2005 22:38:34 GMT\r\n'
-                'Content-Length: 13\r\n'
-                '\r\n'
-                'Hello, world!'
-            .codeUnits);
-        channel.sink.close();
-      }));
+          channel.sink.add(
+            'HTTP/1.1 404 Not Found\r\n'
+                    'date: Mon, 23 May 2005 22:38:34 GMT\r\n'
+                    'Content-Length: 13\r\n'
+                    '\r\n'
+                    'Hello, world!'
+                .codeUnits,
+          );
+          channel.sink.close();
+        }),
+      );
     });
 
     var response = await _post(body: 'Hello');
     expect(response.statusCode, HttpStatus.notFound);
     expect(response.headers['date'], 'Mon, 23 May 2005 22:38:34 GMT');
     expect(
-        response.stream.bytesToString(), completion(equals('Hello, world!')));
+      response.stream.bytesToString(),
+      completion(equals('Hello, world!')),
+    );
   });
 
-  test('reports an error if a HijackException is thrown without hijacking',
-      () async {
-    await _scheduleServer((request) => throw const HijackException());
+  test(
+    'reports an error if a HijackException is thrown without hijacking',
+    () async {
+      await _scheduleServer((request) => throw const HijackException());
 
-    var response = await _get();
-    expect(response.statusCode, HttpStatus.internalServerError);
-  });
+      var response = await _get();
+      expect(response.statusCode, HttpStatus.internalServerError);
+    },
+  );
 
   test('passes asynchronous exceptions to the parent error zone', () async {
-    await runZonedGuarded(() async {
-      var server = await shelf_io.serve((request) {
-        Future(() => throw StateError('oh no'));
-        return syncHandler(request);
-      }, 'localhost', 0);
+    await runZonedGuarded(
+      () async {
+        var server = await shelf_io.serve(
+          (request) {
+            Future(() => throw StateError('oh no'));
+            return syncHandler(request);
+          },
+          'localhost',
+          0,
+        );
 
-      var response = await http.get(Uri.http('localhost:${server.port}', '/'));
-      expect(response.statusCode, HttpStatus.ok);
-      expect(response.body, 'Hello from /');
-      await server.close();
-    }, expectAsync2((error, stack) {
-      expect(error, isOhNoStateError);
-    }));
+        var response = await http.get(
+          Uri.http('localhost:${server.port}', '/'),
+        );
+        expect(response.statusCode, HttpStatus.ok);
+        expect(response.body, 'Hello from /');
+        await server.close();
+      },
+      expectAsync2((error, stack) {
+        expect(error, isOhNoStateError);
+      }),
+    );
   });
 
   test("doesn't pass asynchronous exceptions to the root error zone", () async {
     var response = await Zone.root.run(() async {
-      var server = await shelf_io.serve((request) {
-        Future(() => throw StateError('oh no'));
-        return syncHandler(request);
-      }, 'localhost', 0);
+      var server = await shelf_io.serve(
+        (request) {
+          Future(() => throw StateError('oh no'));
+          return syncHandler(request);
+        },
+        'localhost',
+        0,
+      );
 
       try {
         return await http.get(Uri.http('localhost:${server.port}', '/'));
@@ -307,7 +346,9 @@ void main() {
     }
 
     expect(
-        await utf8.decodeStream(socket), contains('500 Internal Server Error'));
+      await utf8.decodeStream(socket),
+      contains('500 Internal Server Error'),
+    );
   });
 
   test('a bad HTTP URL request results in a 400 response', () async {
@@ -345,8 +386,10 @@ void main() {
     test('defers to header in response', () async {
       var date = DateTime.utc(1981, 6, 5);
       await _scheduleServer((request) {
-        return Response.ok('test',
-            headers: {HttpHeaders.dateHeader: parser.formatHttpDate(date)});
+        return Response.ok(
+          'test',
+          headers: {HttpHeaders.dateHeader: parser.formatHttpDate(date)},
+        );
       });
 
       var response = await _get();
@@ -385,10 +428,7 @@ void main() {
         poweredByHeader: 'ourServer',
       );
       var response = await _get();
-      expect(
-        response.headers,
-        containsPair(poweredBy, 'ourServer'),
-      );
+      expect(response.headers, containsPair(poweredBy, 'ourServer'));
     });
 
     test('defers to header in response when set at the server level', () async {
@@ -414,10 +454,7 @@ void main() {
       );
 
       var response = await _get();
-      expect(
-        response.headers,
-        isNot(contains(poweredBy)),
-      );
+      expect(response.headers, isNot(contains(poweredBy)));
     });
   });
 
@@ -425,60 +462,75 @@ void main() {
     group('is added when the transfer-encoding header is', () {
       test('unset', () async {
         await _scheduleServer((request) {
-          return Response.ok(Stream.fromIterable([
-            [1, 2, 3, 4]
-          ]));
+          return Response.ok(
+            Stream.fromIterable([
+              [1, 2, 3, 4],
+            ]),
+          );
         });
 
         var response = await _get();
-        expect(response.headers,
-            containsPair(HttpHeaders.transferEncodingHeader, 'chunked'));
+        expect(
+          response.headers,
+          containsPair(HttpHeaders.transferEncodingHeader, 'chunked'),
+        );
         expect(response.bodyBytes, equals([1, 2, 3, 4]));
       });
 
       test('"identity"', () async {
         await _scheduleServer((request) {
           return Response.ok(
-              Stream.fromIterable([
-                [1, 2, 3, 4]
-              ]),
-              headers: {HttpHeaders.transferEncodingHeader: 'identity'});
+            Stream.fromIterable([
+              [1, 2, 3, 4],
+            ]),
+            headers: {HttpHeaders.transferEncodingHeader: 'identity'},
+          );
         });
 
         var response = await _get();
-        expect(response.headers,
-            containsPair(HttpHeaders.transferEncodingHeader, 'chunked'));
+        expect(
+          response.headers,
+          containsPair(HttpHeaders.transferEncodingHeader, 'chunked'),
+        );
         expect(response.bodyBytes, equals([1, 2, 3, 4]));
       });
     });
 
-    test('is preserved when the transfer-encoding header is "chunked"',
-        () async {
-      await _scheduleServer((request) {
-        return Response.ok(
+    test(
+      'is preserved when the transfer-encoding header is "chunked"',
+      () async {
+        await _scheduleServer((request) {
+          return Response.ok(
             Stream.fromIterable(['2\r\nhi\r\n0\r\n\r\n'.codeUnits]),
-            headers: {HttpHeaders.transferEncodingHeader: 'chunked'});
-      });
+            headers: {HttpHeaders.transferEncodingHeader: 'chunked'},
+          );
+        });
 
-      var response = await _get();
-      expect(response.headers,
-          containsPair(HttpHeaders.transferEncodingHeader, 'chunked'));
-      expect(response.body, equals('hi'));
-    });
+        var response = await _get();
+        expect(
+          response.headers,
+          containsPair(HttpHeaders.transferEncodingHeader, 'chunked'),
+        );
+        expect(response.body, equals('hi'));
+      },
+    );
 
     group('is not added when', () {
       test('content-length is set', () async {
         await _scheduleServer((request) {
           return Response.ok(
-              Stream.fromIterable([
-                [1, 2, 3, 4]
-              ]),
-              headers: {HttpHeaders.contentLengthHeader: '4'});
+            Stream.fromIterable([
+              [1, 2, 3, 4],
+            ]),
+            headers: {HttpHeaders.contentLengthHeader: '4'},
+          );
         });
 
         var response = await _get();
-        expect(response.headers,
-            isNot(contains(HttpHeaders.transferEncodingHeader)));
+        expect(
+          response.headers,
+          isNot(contains(HttpHeaders.transferEncodingHeader)),
+        );
         expect(response.bodyBytes, equals([1, 2, 3, 4]));
       });
 
@@ -488,8 +540,10 @@ void main() {
         });
 
         var response = await _get();
-        expect(response.headers,
-            isNot(contains(HttpHeaders.transferEncodingHeader)));
+        expect(
+          response.headers,
+          isNot(contains(HttpHeaders.transferEncodingHeader)),
+        );
         expect(response.body, isEmpty);
       });
 
@@ -499,8 +553,10 @@ void main() {
         });
 
         var response = await _get();
-        expect(response.headers,
-            isNot(contains(HttpHeaders.transferEncodingHeader)));
+        expect(
+          response.headers,
+          isNot(contains(HttpHeaders.transferEncodingHeader)),
+        );
         expect(response.body, isEmpty);
       });
 
@@ -510,8 +566,10 @@ void main() {
         });
 
         var response = await _get();
-        expect(response.headers,
-            isNot(contains(HttpHeaders.transferEncodingHeader)));
+        expect(
+          response.headers,
+          isNot(contains(HttpHeaders.transferEncodingHeader)),
+        );
         expect(response.body, isEmpty);
       });
     });
@@ -522,8 +580,10 @@ void main() {
     await _scheduleServer((request) {
       controller.add('Hello, ');
 
-      return Response.ok(utf8.encoder.bind(controller.stream),
-          context: {'shelf.io.buffer_output': false});
+      return Response.ok(
+        utf8.encoder.bind(controller.stream),
+        context: {'shelf.io.buffer_output': false},
+      );
     });
 
     var request = http.Request('GET', Uri.http('localhost:$_serverPort', ''));
@@ -543,8 +603,10 @@ void main() {
 
   test('includes the dart:io HttpConnectionInfo in request context', () async {
     await _scheduleServer((request) {
-      expect(request.context,
-          containsPair('shelf.io.connection_info', isA<HttpConnectionInfo>()));
+      expect(
+        request.context,
+        containsPair('shelf.io.connection_info', isA<HttpConnectionInfo>()),
+      );
 
       var connectionInfo =
           request.context['shelf.io.connection_info'] as HttpConnectionInfo;
@@ -577,8 +639,10 @@ void main() {
 
       var response = await req.close();
       expect(response.statusCode, HttpStatus.ok);
-      expect(await response.cast<List<int>>().transform(utf8.decoder).single,
-          'Hello from /');
+      expect(
+        await response.cast<List<int>>().transform(utf8.decoder).single,
+        'Hello from /',
+      );
     });
 
     test('secure async handler returns a value to the client', () async {
@@ -587,8 +651,10 @@ void main() {
       var req = await scheduleSecureGet();
       var response = await req.close();
       expect(response.statusCode, HttpStatus.ok);
-      expect(await response.cast<List<int>>().transform(utf8.decoder).single,
-          'Hello from /');
+      expect(
+        await response.cast<List<int>>().transform(utf8.decoder).single,
+        'Hello from /',
+      );
     });
   });
 }
@@ -610,16 +676,20 @@ Future<void> _scheduleServer(
   );
 }
 
-Future<http.Response> _get(
-        {Map<String, /* String | List<String> */ Object>? headers,
-        String path = ''}) =>
+Future<http.Response> _get({
+  Map<String, /* String | List<String> */ Object>? headers,
+  String path = '',
+}) =>
     _request((client, url) => client.getUrl(url), headers: headers, path: path);
 
-Future<http.Response> _head(
-        {Map<String, /* String | List<String> */ Object>? headers,
-        String path = ''}) =>
-    _request((client, url) => client.headUrl(url),
-        headers: headers, path: path);
+Future<http.Response> _head({
+  Map<String, /* String | List<String> */ Object>? headers,
+  String path = '',
+}) => _request(
+  (client, url) => client.headUrl(url),
+  headers: headers,
+  path: path,
+);
 
 Future<http.Response> _request(
   Future<HttpClientRequest> Function(HttpClient, Uri) request, {
@@ -638,18 +708,18 @@ Future<http.Response> _request(
     rs.headers.forEach((name, values) {
       rsHeaders[name] = joinHeaderValues(values)!;
     });
-    return http.Response.fromStream(http.StreamedResponse(
-      rs,
-      rs.statusCode,
-      headers: rsHeaders,
-    ));
+    return await http.Response.fromStream(
+      http.StreamedResponse(rs, rs.statusCode, headers: rsHeaders),
+    );
   } finally {
     client.close(force: true);
   }
 }
 
-Future<http.StreamedResponse> _post(
-    {Map<String, String>? headers, String? body}) {
+Future<http.StreamedResponse> _post({
+  Map<String, String>? headers,
+  String? body,
+}) {
   var request = http.Request('POST', Uri.http('localhost:$_serverPort', ''));
 
   if (headers != null) request.headers.addAll(headers);

--- a/pkgs/shelf/test/test_util.dart
+++ b/pkgs/shelf/test/test_util.dart
@@ -19,10 +19,16 @@ final Matcher throwsHijackException = throwsA(isA<HijackException>());
 ///
 /// By default, replies with a status code 200, empty headers, and
 /// `Hello from ${request.url.path}`.
-Response syncHandler(Request request,
-    {int? statusCode, Map<String, String>? headers}) {
-  return Response(statusCode ?? 200,
-      headers: headers, body: 'Hello from ${request.requestedUri.path}');
+Response syncHandler(
+  Request request, {
+  int? statusCode,
+  Map<String, String>? headers,
+}) {
+  return Response(
+    statusCode ?? 200,
+    headers: headers,
+    body: 'Hello from ${request.requestedUri.path}',
+  );
 }
 
 /// Calls [syncHandler] and wraps the response in a [Future].
@@ -37,5 +43,8 @@ final _request = Request('GET', localhostUri);
 
 final localhostUri = Uri.parse('http://localhost/');
 
-final isOhNoStateError =
-    isA<StateError>().having((p0) => p0.message, 'message', 'oh no');
+final isOhNoStateError = isA<StateError>().having(
+  (p0) => p0.message,
+  'message',
+  'oh no',
+);

--- a/pkgs/shelf_web_socket/test/web_socket_test.dart
+++ b/pkgs/shelf_web_socket/test/web_socket_test.dart
@@ -65,7 +65,7 @@ void main() {
       final webSocket = await WebSocket.connect('ws://localhost:${server.port}',
           protocols: ['one', 'two', 'three']);
       expect(webSocket.protocol, equals('two'));
-      return webSocket.close();
+      return await webSocket.close();
     } finally {
       await server.close();
     }
@@ -80,7 +80,7 @@ void main() {
       final webSocket = await WebSocket.connect('ws://localhost:${server.port}',
           protocols: ['one', 'two', 'three']);
       expect(webSocket.protocol, isNull);
-      return webSocket.close();
+      return await webSocket.close();
     } finally {
       await server.close();
     }
@@ -97,7 +97,7 @@ void main() {
       final webSocket = await WebSocket.connect('ws://localhost:${server.port}',
           protocols: ['one', 'two', 'three']);
       expect(webSocket.protocol, isNull);
-      return webSocket.close();
+      return await webSocket.close();
     } finally {
       await server.close();
     }


### PR DESCRIPTION
This PR isolates the SDK version bump for `pkg:shelf` to Dart 3.9.0, along with the associated CI regeneration and code formatting, as part of splitting up #528.