### PR TITLE
fix: join multiple Cookie header values with '; ' instead of ',' (#521)

### DIFF
--- a/pkgs/shelf/CHANGELOG.md
+++ b/pkgs/shelf/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## 1.4.3-wip
 
 * Require `sdk: ^3.9.0`.
+* Join multiple `Cookie` request-header values with `'; '` instead of `','`
+  in the single-value `headers` map, following the cookie-string grammar of
+  [RFC 6265 section 5.4](https://datatracker.ietf.org/doc/html/rfc6265#section-5.4).
 
 ## 1.4.2
 

--- a/pkgs/shelf/lib/src/headers.dart
+++ b/pkgs/shelf/lib/src/headers.dart
@@ -14,7 +14,7 @@ final _emptyHeaders = Headers._empty();
 class Headers extends UnmodifiableMapView<String, List<String>> {
   late final Map<String, String> singleValues = UnmodifiableMapView(
     CaseInsensitiveMap.from(
-      map((key, value) => MapEntry(key, joinHeaderValues(value)!)),
+      map((key, value) => MapEntry(key, joinHeaderValues(value, name: key)!)),
     ),
   );
 

--- a/pkgs/shelf/lib/src/util.dart
+++ b/pkgs/shelf/lib/src/util.dart
@@ -76,12 +76,12 @@ Map<String, Object> removeHeader(Map<String, Object>? headers, String name) {
 String? findHeader(Map<String, List<String>?>? headers, String name) {
   if (headers == null) return null;
   if (headers is ShelfUnmodifiableMap) {
-    return joinHeaderValues(headers[name]);
+    return joinHeaderValues(headers[name], name: name);
   }
 
   for (var key in headers.keys) {
     if (equalsIgnoreAsciiCase(key, name)) {
-      return joinHeaderValues(headers[key]);
+      return joinHeaderValues(headers[key], name: name);
     }
   }
   return null;
@@ -138,9 +138,17 @@ List<String> expandHeaderValue(Object v) {
 
 /// Multiple header values are joined with commas.
 /// See https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-p1-messaging-21#page-22
-String? joinHeaderValues(List<String>? values) {
+///
+/// The `Cookie` header is the one exception: the cookie-string grammar of
+/// RFC 6265 separates cookie-pairs with `; ` and does not allow commas, so
+/// when [name] is `cookie` multiple values are recombined with `; ` as
+/// specified in https://datatracker.ietf.org/doc/html/rfc9113#section-8.2.3
+String? joinHeaderValues(List<String>? values, {String? name}) {
   if (values == null) return null;
   if (values.isEmpty) return '';
   if (values.length == 1) return values.single;
-  return values.join(',');
+  final separator = name != null && equalsIgnoreAsciiCase(name, 'cookie')
+      ? '; '
+      : ',';
+  return values.join(separator);
 }

--- a/pkgs/shelf/test/message_test.dart
+++ b/pkgs/shelf/test/message_test.dart
@@ -95,6 +95,22 @@ void main() {
         'content-length': ['0'],
       });
     });
+
+    test('multiple cookie header values are joined with "; "', () {
+      final message = _createMessage(
+        headers: {
+          'Cookie': ['session=123', 'theme=dark'],
+        },
+      );
+      expect(
+        message.headers,
+        containsPair('cookie', 'session=123; theme=dark'),
+      );
+      expect(
+        message.headersAll,
+        containsPair('cookie', ['session=123', 'theme=dark']),
+      );
+    });
   });
 
   group('context', () {


### PR DESCRIPTION
Fixes #521.

When a message carries multiple `Cookie` header values, the single-value
`headers` map joins them with a comma:

```dart
final request = Request('GET', Uri.parse('http://localhost/'), headers: {
  'Cookie': ['session=123', 'theme=dark'],
});
print(request.headers['cookie']); // session=123,theme=dark
```

The cookie-string grammar of RFC 6265 separates cookie-pairs with `; ` and
does not allow commas, so the joined value is unparseable by servers and
middleware that read `request.headers['cookie']`. This also happens on the
real server path: `dart:io` delivers repeated `Cookie` lines as separate
list entries, which `shelf_io` passes through to `headersAll`, and the
`headers` view then comma-joins them.

The joining happens in `joinHeaderValues` in `lib/src/util.dart`, which
uses `,` unconditionally. Comma is correct for every header except
`Cookie`; RFC 9113 section 8.2.3 specifies that split cookie fields must
be recombined with the two-octet delimiter `; `.

This change gives `joinHeaderValues` an optional `name` parameter and uses
`; ` when the name is `cookie` (case-insensitive). `Headers.singleValues`
and `findHeader` pass the header name through. The two remaining call
sites in `message.dart` join `content-type` and `transfer-encoding` and
are unchanged. `headersAll` is unaffected.

After the change the example above prints `session=123; theme=dark`, and
the same is true end to end for a request sent over a socket with two
`Cookie` lines.

Added a test in `message_test.dart` next to the existing multi-value
header test; it fails with `session=123,theme=dark` before the fix. The
existing "headers with multiple values" test guards that non-cookie
headers still join with a comma. The full `pkgs/shelf` suite passes
(231 tests), and `dart analyze` and `dart format` are clean.
