### PR TITLE
fix(shelf_static): Handle int overflow during byte range parsing

### DIFF
--- a/pkgs/shelf_static/CHANGELOG.md
+++ b/pkgs/shelf_static/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 1.2.0-wip
 
+* Fix unhandled `FormatException` / HTTP 500 error when parsing oversized integer
+  values in HTTP `Range` headers.
 * Replace static, blocking `dart:io` operations (such as `statSync()` and
   `File.existsSync()`) with their asynchronous equivalents. This prevents
   `createStaticHandler` from blocking the Dart isolate event loop, dramatically

--- a/pkgs/shelf_static/lib/src/static_handler.dart
+++ b/pkgs/shelf_static/lib/src/static_handler.dart
@@ -322,24 +322,30 @@ Response? _fileRangeResponse(
     end = actualLength - 1;
   } else {
     final parsedStart = int.tryParse(startMatch);
-    start = parsedStart ?? actualLength;
-    if (endMatch.isEmpty) {
-      end = actualLength - 1;
-    } else {
-      end = int.tryParse(endMatch) ?? actualLength - 1;
+    final parsedEnd = endMatch.isEmpty ? null : int.tryParse(endMatch);
+
+    // If end is specified and start > end, range is syntactically invalid
+    // (RFC 2616 / RFC 7233).
+    if (endMatch.isNotEmpty) {
+      if (parsedStart == null && parsedEnd != null) return null;
+      if (parsedStart != null && parsedEnd != null && parsedStart > parsedEnd) {
+        return null;
+      }
     }
+
+    if (parsedStart == null || parsedStart >= actualLength) {
+      return Response(
+        HttpStatus.requestedRangeNotSatisfiable,
+        headers: headers,
+      );
+    }
+
+    start = parsedStart;
+    end = (parsedEnd == null || parsedEnd >= actualLength)
+        ? actualLength - 1
+        : parsedEnd;
   }
 
-  // If the range is syntactically invalid the Range header
-  // MUST be ignored (RFC 2616 section 14.35.1).
-  if (start > end) return null;
-
-  if (end >= actualLength) {
-    end = actualLength - 1;
-  }
-  if (start >= actualLength) {
-    return Response(HttpStatus.requestedRangeNotSatisfiable, headers: headers);
-  }
   return Response(
     HttpStatus.partialContent,
     body: request.method == 'HEAD' ? null : file.openRead(start, end + 1),

--- a/pkgs/shelf_static/lib/src/static_handler.dart
+++ b/pkgs/shelf_static/lib/src/static_handler.dart
@@ -284,7 +284,7 @@ String _defaultGenerateETag(File file, FileStat stat) =>
 
 final _bytesMatcher = RegExp(r'^bytes=(\d*)-(\d*)$');
 
-/// Serves a range of [file], if [request] is valid 'bytes' range request.
+/// Serves a range of [file], if [request] is a valid 'bytes' range request.
 ///
 /// If the request does not specify a range, specifies a range of the wrong
 /// type, or has a syntactic error the range is ignored and `null` is returned.
@@ -312,6 +312,10 @@ Response? _fileRangeResponse(
   int start; // First byte position - inclusive.
   int end; // Last byte position - inclusive.
   if (startMatch.isEmpty) {
+    // `endMatch` is guaranteed non-empty because `"bytes=-"` is rejected above.
+    // If `parsedEnd` is null, the suffix length exceeds the 64-bit int range.
+    // Per RFC 7233 § 2.1, if the suffix length is larger than the file length,
+    // the entire file is used (start = 0).
     final parsedEnd = int.tryParse(endMatch);
     if (parsedEnd == null) {
       start = 0;
@@ -333,6 +337,8 @@ Response? _fileRangeResponse(
       }
     }
 
+    // Since `startMatch` is not empty, if `parsedStart` is null then it
+    // must be larger than can fit in the Dart `int` type (overflow).
     if (parsedStart == null || parsedStart >= actualLength) {
       return Response(
         HttpStatus.requestedRangeNotSatisfiable,

--- a/pkgs/shelf_static/lib/src/static_handler.dart
+++ b/pkgs/shelf_static/lib/src/static_handler.dart
@@ -312,12 +312,22 @@ Response? _fileRangeResponse(
   int start; // First byte position - inclusive.
   int end; // Last byte position - inclusive.
   if (startMatch.isEmpty) {
-    start = actualLength - int.parse(endMatch);
-    if (start < 0) start = 0;
+    final parsedEnd = int.tryParse(endMatch);
+    if (parsedEnd == null) {
+      start = 0;
+    } else {
+      start = actualLength - parsedEnd;
+      if (start < 0) start = 0;
+    }
     end = actualLength - 1;
   } else {
-    start = int.parse(startMatch);
-    end = endMatch.isEmpty ? actualLength - 1 : int.parse(endMatch);
+    final parsedStart = int.tryParse(startMatch);
+    start = parsedStart ?? actualLength;
+    if (endMatch.isEmpty) {
+      end = actualLength - 1;
+    } else {
+      end = int.tryParse(endMatch) ?? actualLength - 1;
+    }
   }
 
   // If the range is syntactically invalid the Range header

--- a/pkgs/shelf_static/test/create_file_handler_test.dart
+++ b/pkgs/shelf_static/test/create_file_handler_test.dart
@@ -178,6 +178,37 @@ void main() {
       expect(response.contentLength, equals(8));
       expect(response.readAsString(), completion(equals('contents')));
     });
+    test('ignores request with start overflow', () async {
+      final handler = createFileHandler(p.join(d.sandbox, 'file.txt'));
+      final response = await makeRequest(
+        handler,
+        '/file.txt',
+        headers: {'range': 'bytes=99999999999999999999-'},
+      );
+      expect(response.statusCode, equals(HttpStatus.ok));
+    });
+
+    test('ignores request with end overflow', () async {
+      final handler = createFileHandler(p.join(d.sandbox, 'file.txt'));
+      final response = await makeRequest(
+        handler,
+        '/file.txt',
+        headers: {'range': 'bytes=0-99999999999999999999'},
+      );
+      expect(response.statusCode, equals(HttpStatus.partialContent));
+      expect(response.contentLength, equals(8));
+    });
+
+    test('ignores request with suffix overflow', () async {
+      final handler = createFileHandler(p.join(d.sandbox, 'file.txt'));
+      final response = await makeRequest(
+        handler,
+        '/file.txt',
+        headers: {'range': 'bytes=-99999999999999999999'},
+      );
+      expect(response.statusCode, equals(HttpStatus.partialContent));
+      expect(response.contentLength, equals(8));
+    });
   });
 
   group('throws an ArgumentError for', () {

--- a/pkgs/shelf_static/test/create_file_handler_test.dart
+++ b/pkgs/shelf_static/test/create_file_handler_test.dart
@@ -178,14 +178,30 @@ void main() {
       expect(response.contentLength, equals(8));
       expect(response.readAsString(), completion(equals('contents')));
     });
-    test('ignores request with start overflow', () async {
+    test('rejects request with start overflow', () async {
       final handler = createFileHandler(p.join(d.sandbox, 'file.txt'));
       final response = await makeRequest(
         handler,
         '/file.txt',
         headers: {'range': 'bytes=99999999999999999999-'},
       );
-      expect(response.statusCode, equals(HttpStatus.ok));
+      expect(
+        response.statusCode,
+        equals(HttpStatus.requestedRangeNotSatisfiable),
+      );
+    });
+
+    test('rejects open-ended request with start past EOF', () async {
+      final handler = createFileHandler(p.join(d.sandbox, 'file.txt'));
+      final response = await makeRequest(
+        handler,
+        '/file.txt',
+        headers: {'range': 'bytes=8-'},
+      );
+      expect(
+        response.statusCode,
+        equals(HttpStatus.requestedRangeNotSatisfiable),
+      );
     });
 
     test('ignores request with end overflow', () async {


### PR DESCRIPTION
Uses int.tryParse() to gracefully handle extremely large integers in Range header parsing, avoiding unhandled FormatException / 500 error.